### PR TITLE
set maximum buffer size properly when constructing a BufferManger

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Bindings/BufferManager.cs
+++ b/Stack/Opc.Ua.Core/Stack/Bindings/BufferManager.cs
@@ -119,10 +119,14 @@ namespace Opc.Ua.Bindings
         public BufferManager(string name, int maxPoolSize, int maxBufferSize)
         {
             m_name      = name;
-            m_manager   = System.ServiceModel.Channels.BufferManager.CreateBufferManager(maxPoolSize, maxBufferSize);
+#if TRACK_MEMORY
+            m_manager = System.ServiceModel.Channels.BufferManager.CreateBufferManager(maxPoolSize, maxBufferSize + 5);
+#else
+            m_manager = System.ServiceModel.Channels.BufferManager.CreateBufferManager(maxPoolSize, maxBufferSize + 1);
+#endif
         }
         #endregion
-        
+
         #region Public Methods
         /// <summary>
         /// Returns a buffer with at least the specified size.


### PR DESCRIPTION
TakeBuffer method of the BufferManager before forwarding the call to the internal BufferManager increases the expected size this causes it to be bigger than the maximum configured buffer size. At construction internal BufferManager should be configured properly.