### PR TITLE
fix a duplicate ReturnBuffer call, improve the BufferManager tracing.

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
@@ -476,6 +476,10 @@ namespace Opc.Ua.Bindings
                 {
                     // send notification (implementor responsible for freeing buffer) on success.
                     ArraySegment<byte> messageChunk = new ArraySegment<byte>(m_receiveBuffer, 0, m_incomingMessageSize);
+
+                    // must allocate a new buffer for the next message.
+                    m_receiveBuffer = null;
+
                     m_sink.OnMessageReceived(this, messageChunk);
                 }
                 catch (Exception ex)


### PR DESCRIPTION
@barnstee fix for #55. In fact this was a problem on all platforms, the read loop almost everytime freed the buffer twice.