### PR TITLE
To be able to clone a DataChangeFilter object

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -1475,6 +1475,15 @@ namespace Opc.Ua
                 }
             }
 
+            // copy DataChangeFilter.
+            {
+                DataChangeFilter castedObject = value as DataChangeFilter;
+                if (castedObject != null)
+                {
+                    return castedObject.MemberwiseClone();
+                }
+            }
+
             // copy SimpleAttributeOperandCollection.
             {
                 SimpleAttributeOperandCollection castedObject = value as SimpleAttributeOperandCollection;


### PR DESCRIPTION
While trying a sample application one month ago, i needed to do this to add a deadband filter to a monitored item.

Best.
