### PR TITLE
Added support for LDS-ME (merged from https://github.com/cristipogacean/UA-.NET)

### DIFF
--- a/SampleApplications/SDK/Opc.Ua.Server/Server/StandardServer.cs
+++ b/SampleApplications/SDK/Opc.Ua.Server/Server/StandardServer.cs
@@ -2178,8 +2178,29 @@ namespace Opc.Ua.Server
                             requestHeader.Timestamp = DateTime.UtcNow;
 
                             client.OperationTimeout = 10000;
-                            client.RegisterServer(requestHeader, m_registrationInfo);
-                            return true;
+	                        try
+	                        {
+	                            ExtensionObjectCollection discoveryConfiguration = new ExtensionObjectCollection();
+	                            StatusCodeCollection configurationResults = null;
+	                            DiagnosticInfoCollection diagnosticInfos = null;
+
+	                            client.RegisterServer2(
+	                                requestHeader,
+	                                m_registrationInfo,
+	                                discoveryConfiguration,
+	                                out configurationResults,
+	                                out diagnosticInfos);
+
+	                            return true;
+	                        }
+	                        catch (Exception e)
+	                        {
+	                            // fall back to calling RegisterServer in case RegisterServer2 fails.
+	                            Utils.Trace("RegisterServer2 failed for: {0}. Falling back to RegisterServer. Exception={1}.", endpoint.EndpointUrl, e.Message);
+
+	                            client.RegisterServer(requestHeader, m_registrationInfo);
+	                            return true;
+	                        }
                         }
                         catch (Exception e)
                         {

--- a/SampleApplications/Samples/ClientControls.Net4/Common/DiscoveredServerOnNetworkListCtrl.Designer.cs
+++ b/SampleApplications/Samples/ClientControls.Net4/Common/DiscoveredServerOnNetworkListCtrl.Designer.cs
@@ -1,0 +1,73 @@
+/* ========================================================================
+ * Copyright (c) 2005-2016 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua.Client.Controls
+{
+    partial class DiscoveredServerOnNetworkListCtrl
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.SuspendLayout();
+            // 
+            // UserAccountListCtrl
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.Name = "UserAccountListCtrl";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+    }
+}

--- a/SampleApplications/Samples/ClientControls.Net4/Common/DiscoveredServerOnNetworkListCtrl.cs
+++ b/SampleApplications/Samples/ClientControls.Net4/Common/DiscoveredServerOnNetworkListCtrl.cs
@@ -1,0 +1,304 @@
+/* ========================================================================
+ * Copyright (c) 2005-2016 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+using System.Threading;
+
+using Opc.Ua.Client.Controls;
+
+namespace Opc.Ua.Client.Controls
+{
+    /// <summary>
+    /// Displays a list of servers.
+    /// </summary>
+    public partial class DiscoveredServerOnNetworkListCtrl : Opc.Ua.Client.Controls.BaseListCtrl
+    {
+        #region Constructors
+        /// <summary>
+        /// Initalize the control.
+        /// </summary>
+        public DiscoveredServerOnNetworkListCtrl()
+        {
+            InitializeComponent();
+            SetColumns(m_ColumnNames);
+            ItemsLV.Sorting = SortOrder.Descending;
+            ItemsLV.MultiSelect = false;
+        }
+        #endregion
+        
+        #region Private Fields
+        // The columns to display in the control.		
+		private readonly object[][] m_ColumnNames = new object[][]
+		{ 
+			new object[] { "RecordId", HorizontalAlignment.Left, null },  
+			new object[] { "ServerName", HorizontalAlignment.Left, null },
+			new object[] { "DiscoveryUrl", HorizontalAlignment.Left, null },
+			new object[] { "ServerCapabilities",  HorizontalAlignment.Left, null }
+		};
+        
+        private ApplicationConfiguration m_configuration;
+        private int m_discoveryTimeout;
+        private int m_discoverCount;
+        private string m_discoveryUrl;
+        private NumericUpDown m_startingRecordIdUpDown;
+        private NumericUpDown m_maxRecordsToReturnUpDown;
+        private TextBox m_capabilityFilterTextBox;
+
+
+        #endregion
+
+        #region Public Interface
+        /// <summary>
+        /// The timeout in milliseconds to use when discovering servers.
+        /// </summary>
+        [System.ComponentModel.DefaultValue(5000)]
+        public int DiscoveryTimeout
+        {
+            get { return m_discoveryTimeout; }
+            set { m_discoveryTimeout = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the discovery URL used to find the servers displayed in the control.
+        /// </summary>
+        /// <value>The discovery URL.</value>
+        public string DiscoveryUrl
+        {
+            get { return m_discoveryUrl; }
+            set { m_discoveryUrl = value; }
+        }
+
+        /// <summary>
+        /// Displays a list of servers in the control.
+        /// </summary>
+        public void Initialize(string hostname, NumericUpDown startingRecordId, NumericUpDown maxRecordsToReturn, TextBox capabilityFilterText, ApplicationConfiguration configuration)
+        {
+            Interlocked.Exchange(ref m_configuration, configuration);
+            ItemsLV.Items.Clear();
+            m_startingRecordIdUpDown = startingRecordId;
+            m_maxRecordsToReturnUpDown = maxRecordsToReturn;
+            m_capabilityFilterTextBox = capabilityFilterText;
+
+            if (String.IsNullOrEmpty(hostname))
+            {
+                hostname = System.Net.Dns.GetHostName();
+            }
+            
+            this.Instructions = Utils.Format("Discovering servers on host '{0}'.", hostname);
+            AdjustColumns();
+
+            // get a list of well known discovery urls to use.
+            StringCollection discoveryUrls = null;
+
+            if (configuration != null && configuration.ClientConfiguration != null)
+            {
+                discoveryUrls = configuration.ClientConfiguration.WellKnownDiscoveryUrls;
+            }
+
+            if (discoveryUrls == null || discoveryUrls.Count == 0)
+            {
+                discoveryUrls = new StringCollection(Utils.DiscoveryUrls);
+            }
+            
+            // update the urls with the hostname.
+            StringCollection urlsToUse = new StringCollection();
+
+            foreach (string discoveryUrl in discoveryUrls)
+            {
+                urlsToUse.Add(Utils.Format(discoveryUrl, hostname));
+            }
+
+            Interlocked.Increment(ref m_discoverCount);
+            ThreadPool.QueueUserWorkItem(new WaitCallback(OnDiscoverServersOnNetwork), urlsToUse);
+        }
+
+        /// <summary>
+        /// Updates the list of servers displayed in the control.
+        /// </summary>
+        private void OnUpdateServers(object state)
+        {
+            if (this.InvokeRequired)
+            {
+                this.BeginInvoke(new WaitCallback(OnUpdateServers), state);
+                return;
+            }
+            
+            ItemsLV.Items.Clear();
+
+            ServerOnNetworkCollection servers = state as ServerOnNetworkCollection;
+
+            if (servers != null)
+            {
+                foreach (ServerOnNetwork server in servers)
+                {
+                    AddItem(server);
+                }
+            }
+
+            if (ItemsLV.Items.Count == 0)
+            {
+                this.Instructions = Utils.Format("No servers to display.");
+            }
+
+            AdjustColumns();
+        }
+
+        /// <summary>
+        /// Attempts fetch the list of network servers from the discovery server.
+        /// </summary>
+        private void OnDiscoverServersOnNetwork(object state)
+        {
+            try
+            {
+                int discoverCount = m_discoverCount;
+
+                // do nothing if a valid list is not provided.
+                IList<string> discoveryUrls = state as IList<string>;
+
+                if (discoveryUrls == null)
+                {
+                    return;
+                }
+
+                // process each url.
+                foreach (string discoveryUrl in discoveryUrls)
+                {
+                    Uri url = Utils.ParseUri(discoveryUrl);
+
+                    if (url != null)
+                    {
+                        if (DiscoverServersOnNetwork(url))
+                        {
+                            return;
+                        }
+
+                        // check if another discover operation has started.
+                        if (discoverCount != m_discoverCount)
+                        {
+                            return;
+                        }
+                    }
+                }
+
+                // display empty list.
+                OnUpdateServers(null);
+            }
+            catch (Exception e)
+            {
+                Utils.Trace(e, "Unexpected error discovering servers.");
+            }
+        }
+
+        /// <summary>
+        /// Fetches the network servers from the discovery server.
+        /// </summary>
+        private bool DiscoverServersOnNetwork(Uri discoveryUrl)
+        {
+            // use a short timeout.
+            EndpointConfiguration configuration = EndpointConfiguration.Create(m_configuration);
+            configuration.OperationTimeout = m_discoveryTimeout;
+            DiscoveryClient client = null;
+
+            try
+            {
+                client = DiscoveryClient.Create(
+                    discoveryUrl,
+                    EndpointConfiguration.Create(m_configuration));
+
+                uint startingRecordId = (uint)0;
+                uint maxRecordsToReturn = (uint)0;
+                StringCollection serverCapabilityFilter = new StringCollection();
+                DateTime lastCounterResetTime = DateTime.MinValue;
+
+                try
+                {
+                    startingRecordId = (uint)m_startingRecordIdUpDown.Value;
+                    maxRecordsToReturn = (uint)m_maxRecordsToReturnUpDown.Value;
+
+                    if (!String.IsNullOrEmpty(m_capabilityFilterTextBox.Text))
+                    {
+                        serverCapabilityFilter = new StringCollection(m_capabilityFilterTextBox.Text.Split(','));
+                    }
+                }
+                catch (Exception e)
+                {
+                    Utils.Trace("Error retrieving FindServersOnNetwork paramters. Error=({1}){0}", e.Message, e.GetType());
+                    return false;
+                }
+
+                ServerOnNetworkCollection servers = client.FindServersOnNetwork(startingRecordId, maxRecordsToReturn, serverCapabilityFilter, out lastCounterResetTime);
+                m_discoveryUrl = discoveryUrl.ToString();
+                OnUpdateServers(servers);
+                return true;
+            }
+            catch (Exception e)
+            {
+                Utils.Trace("DISCOVERY ERROR - Could not fetch servers from url: {0}. Error=({2}){1}", discoveryUrl, e.Message, e.GetType());
+                return false;
+            }
+            finally
+            {
+                if (client != null)
+                {
+                    client.Close();
+                }
+            }
+        }
+        #endregion
+
+        #region Overridden Methods
+        /// <summary>
+        /// Updates an item in the control.
+        /// </summary>
+        protected override void UpdateItem(ListViewItem listItem, object item)
+        {
+            ServerOnNetwork server = listItem.Tag as ServerOnNetwork;
+
+            if (server == null)
+            {
+                base.UpdateItem(listItem, server);
+                return;
+            }
+
+            listItem.SubItems[0].Text = String.Format("{0}", server.RecordId);
+            listItem.SubItems[1].Text = String.Format("{0}", server.ServerName);
+            listItem.SubItems[2].Text = String.Format("{0}", server.DiscoveryUrl);
+            listItem.SubItems[3].Text = String.Format("{0}", string.Join(",", server.ServerCapabilities)); 
+
+            listItem.ImageKey = GuiUtils.Icons.Service;
+        }
+        #endregion
+    }
+}

--- a/SampleApplications/Samples/ClientControls.Net4/Common/DiscoveredServerOnNetworkListCtrl.resx
+++ b/SampleApplications/Samples/ClientControls.Net4/Common/DiscoveredServerOnNetworkListCtrl.resx
@@ -112,15 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="MainMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="StatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>229, 17</value>
-  </metadata>
 </root>

--- a/SampleApplications/Samples/ClientControls.Net4/Common/DiscoveredServerOnNetworkListDlg.Designer.cs
+++ b/SampleApplications/Samples/ClientControls.Net4/Common/DiscoveredServerOnNetworkListDlg.Designer.cs
@@ -1,0 +1,283 @@
+/* ========================================================================
+ * Copyright (c) 2005-2016 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+namespace Opc.Ua.Client.Controls
+{
+    partial class DiscoveredServerOnNetworkListDlg
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.ButtonsPN = new System.Windows.Forms.Panel();
+            this.OkBTN = new System.Windows.Forms.Button();
+            this.CancelBTN = new System.Windows.Forms.Button();
+            this.MainPN = new System.Windows.Forms.Panel();
+            this.TopPN = new System.Windows.Forms.Panel();
+            this.HostNameLB = new System.Windows.Forms.Label();
+            this.StartingRecordLB = new System.Windows.Forms.Label();
+            this.CapabilityFilterTB = new System.Windows.Forms.TextBox();
+            this.StartingRecordUP = new System.Windows.Forms.NumericUpDown();
+            this.CapabilityFilterLB = new System.Windows.Forms.Label();
+            this.ServersCTRL = new Opc.Ua.Client.Controls.DiscoveredServerOnNetworkListCtrl();
+            this.HostNameCTRL = new Opc.Ua.Client.Controls.SelectHostCtrl();
+            this.MaxRecordsUP = new System.Windows.Forms.NumericUpDown();
+            this.MaxRecordsLB = new System.Windows.Forms.Label();
+            this.ButtonsPN.SuspendLayout();
+            this.MainPN.SuspendLayout();
+            this.TopPN.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.StartingRecordUP)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.MaxRecordsUP)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // ButtonsPN
+            // 
+            this.ButtonsPN.Controls.Add(this.OkBTN);
+            this.ButtonsPN.Controls.Add(this.CancelBTN);
+            this.ButtonsPN.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.ButtonsPN.Location = new System.Drawing.Point(2, 424);
+            this.ButtonsPN.Name = "ButtonsPN";
+            this.ButtonsPN.Size = new System.Drawing.Size(673, 31);
+            this.ButtonsPN.TabIndex = 0;
+            // 
+            // OkBTN
+            // 
+            this.OkBTN.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.OkBTN.Location = new System.Drawing.Point(4, 4);
+            this.OkBTN.Name = "OkBTN";
+            this.OkBTN.Size = new System.Drawing.Size(75, 23);
+            this.OkBTN.TabIndex = 1;
+            this.OkBTN.Text = "OK";
+            this.OkBTN.UseVisualStyleBackColor = true;
+            this.OkBTN.Click += new System.EventHandler(this.OkBTN_Click);
+            // 
+            // CancelBTN
+            // 
+            this.CancelBTN.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.CancelBTN.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.CancelBTN.Location = new System.Drawing.Point(594, 4);
+            this.CancelBTN.Name = "CancelBTN";
+            this.CancelBTN.Size = new System.Drawing.Size(75, 23);
+            this.CancelBTN.TabIndex = 0;
+            this.CancelBTN.Text = "Cancel";
+            this.CancelBTN.UseVisualStyleBackColor = true;
+            // 
+            // MainPN
+            // 
+            this.MainPN.Controls.Add(this.ServersCTRL);
+            this.MainPN.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MainPN.Location = new System.Drawing.Point(2, 55);
+            this.MainPN.Name = "MainPN";
+            this.MainPN.Padding = new System.Windows.Forms.Padding(0, 3, 0, 0);
+            this.MainPN.Size = new System.Drawing.Size(673, 369);
+            this.MainPN.TabIndex = 2;
+            // 
+            // TopPN
+            // 
+            this.TopPN.Controls.Add(this.MaxRecordsUP);
+            this.TopPN.Controls.Add(this.MaxRecordsLB);
+            this.TopPN.Controls.Add(this.CapabilityFilterLB);
+            this.TopPN.Controls.Add(this.StartingRecordUP);
+            this.TopPN.Controls.Add(this.CapabilityFilterTB);
+            this.TopPN.Controls.Add(this.StartingRecordLB);
+            this.TopPN.Controls.Add(this.HostNameLB);
+            this.TopPN.Controls.Add(this.HostNameCTRL);
+            this.TopPN.Dock = System.Windows.Forms.DockStyle.Top;
+            this.TopPN.Location = new System.Drawing.Point(2, 2);
+            this.TopPN.Name = "TopPN";
+            this.TopPN.Size = new System.Drawing.Size(673, 53);
+            this.TopPN.TabIndex = 1;
+            // 
+            // HostNameLB
+            // 
+            this.HostNameLB.AutoSize = true;
+            this.HostNameLB.Location = new System.Drawing.Point(0, 32);
+            this.HostNameLB.Name = "HostNameLB";
+            this.HostNameLB.Size = new System.Drawing.Size(60, 13);
+            this.HostNameLB.TabIndex = 0;
+            this.HostNameLB.Text = "Host Name";
+            this.HostNameLB.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // StartingRecordLB
+            // 
+            this.StartingRecordLB.AutoSize = true;
+            this.StartingRecordLB.Location = new System.Drawing.Point(0, 6);
+            this.StartingRecordLB.Name = "StartingRecordLB";
+            this.StartingRecordLB.Size = new System.Drawing.Size(87, 13);
+            this.StartingRecordLB.TabIndex = 2;
+            this.StartingRecordLB.Text = "StartingRecordId";
+            this.StartingRecordLB.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // CapabilityFilterTB
+            // 
+            this.CapabilityFilterTB.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.CapabilityFilterTB.Location = new System.Drawing.Point(414, 5);
+            this.CapabilityFilterTB.Name = "CapabilityFilterTB";
+            this.CapabilityFilterTB.Size = new System.Drawing.Size(184, 20);
+            this.CapabilityFilterTB.TabIndex = 4;
+            // 
+            // StartingRecordUP
+            // 
+            this.StartingRecordUP.Location = new System.Drawing.Point(88, 3);
+            this.StartingRecordUP.Maximum = new decimal(new int[] {
+            0,
+            1,
+            0,
+            0});
+            this.StartingRecordUP.Name = "StartingRecordUP";
+            this.StartingRecordUP.Size = new System.Drawing.Size(45, 20);
+            this.StartingRecordUP.TabIndex = 15;
+            // 
+            // CapabilityFilterLB
+            // 
+            this.CapabilityFilterLB.AutoSize = true;
+            this.CapabilityFilterLB.Location = new System.Drawing.Point(303, 7);
+            this.CapabilityFilterLB.Name = "CapabilityFilterLB";
+            this.CapabilityFilterLB.Size = new System.Drawing.Size(105, 13);
+            this.CapabilityFilterLB.TabIndex = 16;
+            this.CapabilityFilterLB.Text = "ServerCapabilityFilter";
+            this.CapabilityFilterLB.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // ServersCTRL
+            // 
+            this.ServersCTRL.Cursor = System.Windows.Forms.Cursors.Default;
+            this.ServersCTRL.DiscoveryTimeout = 0;
+            this.ServersCTRL.DiscoveryUrl = null;
+            this.ServersCTRL.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ServersCTRL.Instructions = null;
+            this.ServersCTRL.Location = new System.Drawing.Point(0, 3);
+            this.ServersCTRL.Name = "ServersCTRL";
+            this.ServersCTRL.Size = new System.Drawing.Size(673, 366);
+            this.ServersCTRL.TabIndex = 0;
+            this.ServersCTRL.ItemsPicked += new Opc.Ua.Client.Controls.ListItemActionEventHandler(this.ServersCTRL_ItemsPicked);
+            this.ServersCTRL.ItemsSelected += new Opc.Ua.Client.Controls.ListItemActionEventHandler(this.ServersCTRL_ItemsSelected);
+            // 
+            // HostNameCTRL
+            // 
+            this.HostNameCTRL.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.HostNameCTRL.CommandText = "Discover";
+            this.HostNameCTRL.Location = new System.Drawing.Point(87, 30);
+            this.HostNameCTRL.Margin = new System.Windows.Forms.Padding(0);
+            this.HostNameCTRL.MaximumSize = new System.Drawing.Size(4096, 24);
+            this.HostNameCTRL.MinimumSize = new System.Drawing.Size(400, 21);
+            this.HostNameCTRL.Name = "HostNameCTRL";
+            this.HostNameCTRL.Padding = new System.Windows.Forms.Padding(2, 0, 0, 0);
+            this.HostNameCTRL.Size = new System.Drawing.Size(586, 21);
+            this.HostNameCTRL.TabIndex = 1;
+            this.HostNameCTRL.HostSelected += new System.EventHandler<Opc.Ua.Client.Controls.SelectHostCtrlEventArgs>(this.HostNameCTRL_HostSelected);
+            this.HostNameCTRL.HostConnected += new System.EventHandler<Opc.Ua.Client.Controls.SelectHostCtrlEventArgs>(this.HostNameCTRL_HostConnected);
+            // 
+            // MaxRecordsUP
+            // 
+            this.MaxRecordsUP.Location = new System.Drawing.Point(252, 4);
+            this.MaxRecordsUP.Maximum = new decimal(new int[] {
+            0,
+            1,
+            0,
+            0});
+            this.MaxRecordsUP.Name = "MaxRecordsUP";
+            this.MaxRecordsUP.Size = new System.Drawing.Size(45, 20);
+            this.MaxRecordsUP.TabIndex = 18;
+            // 
+            // MaxRecordsLB
+            // 
+            this.MaxRecordsLB.AutoSize = true;
+            this.MaxRecordsLB.Location = new System.Drawing.Point(138, 6);
+            this.MaxRecordsLB.Name = "MaxRecordsLB";
+            this.MaxRecordsLB.Size = new System.Drawing.Size(112, 13);
+            this.MaxRecordsLB.TabIndex = 17;
+            this.MaxRecordsLB.Text = "MaxRecordsToReturn";
+            this.MaxRecordsLB.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // DiscoveredServerOnNetworkListDlg
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(677, 455);
+            this.Controls.Add(this.MainPN);
+            this.Controls.Add(this.TopPN);
+            this.Controls.Add(this.ButtonsPN);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
+            this.Name = "DiscoveredServerOnNetworkListDlg";
+            this.Padding = new System.Windows.Forms.Padding(2, 2, 2, 0);
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Discover Servers On Network";
+            this.ButtonsPN.ResumeLayout(false);
+            this.MainPN.ResumeLayout(false);
+            this.TopPN.ResumeLayout(false);
+            this.TopPN.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.StartingRecordUP)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.MaxRecordsUP)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Panel ButtonsPN;
+        private System.Windows.Forms.Button OkBTN;
+        private System.Windows.Forms.Button CancelBTN;
+        private System.Windows.Forms.Panel MainPN;
+        private DiscoveredServerOnNetworkListCtrl ServersCTRL;
+        private SelectHostCtrl HostNameCTRL;
+        private System.Windows.Forms.Panel TopPN;
+        private System.Windows.Forms.Label HostNameLB;
+        private System.Windows.Forms.Label StartingRecordLB;
+        private System.Windows.Forms.TextBox CapabilityFilterTB;
+        private System.Windows.Forms.NumericUpDown StartingRecordUP;
+        private System.Windows.Forms.Label CapabilityFilterLB;
+        private System.Windows.Forms.NumericUpDown MaxRecordsUP;
+        private System.Windows.Forms.Label MaxRecordsLB;
+    }
+}

--- a/SampleApplications/Samples/ClientControls.Net4/Common/DiscoveredServerOnNetworkListDlg.cs
+++ b/SampleApplications/Samples/ClientControls.Net4/Common/DiscoveredServerOnNetworkListDlg.cs
@@ -1,0 +1,183 @@
+/* ========================================================================
+ * Copyright (c) 2005-2016 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+using System.Reflection;
+
+namespace Opc.Ua.Client.Controls
+{
+    /// <summary>
+    /// Allows the user to browse a list of servers.
+    /// </summary>
+    public partial class DiscoveredServerOnNetworkListDlg : Form
+    {
+        #region Constructors
+        /// <summary>
+        /// Initializes the dialog.
+        /// </summary>
+        public DiscoveredServerOnNetworkListDlg()
+        {
+            InitializeComponent();
+            this.Icon = ClientUtils.GetAppIcon();
+        }
+        #endregion
+        
+        #region Private Fields
+        private string m_hostname;
+        private ServerOnNetwork m_server;
+        private ApplicationConfiguration m_configuration;
+        #endregion
+        
+        #region Public Interface
+        /// <summary>
+        /// Displays the dialog.
+        /// </summary>
+        public ServerOnNetwork ShowDialog(string hostname, ApplicationConfiguration configuration)
+        {
+            m_configuration = configuration;
+
+            if (String.IsNullOrEmpty(hostname))
+            {
+                hostname = System.Net.Dns.GetHostName();
+            }
+
+            m_hostname = hostname;
+            List<string> hostnames = new List<string>();
+
+            HostNameCTRL.Initialize(hostname, hostnames);
+            ServersCTRL.Initialize(m_hostname, this.StartingRecordUP, this.MaxRecordsUP, this.CapabilityFilterTB, m_configuration);
+
+            OkBTN.Enabled = false;
+
+            if (ShowDialog() != DialogResult.OK)
+            {
+                return null;
+            }
+  
+            return m_server;
+        }
+        #endregion
+        
+        #region Event Handlers
+        private void OkBTN_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                DialogResult = DialogResult.OK;
+            }
+            catch (Exception exception)
+            {
+                GuiUtils.HandleException(this.Text, MethodBase.GetCurrentMethod(), exception);
+            }
+        }
+
+        private void HostNameCTRL_HostSelected(object sender, SelectHostCtrlEventArgs e)
+        {
+            try
+            {
+                if (m_hostname != e.Hostname)
+                {
+                    m_hostname = e.Hostname;
+                    ServersCTRL.Initialize(m_hostname,this.StartingRecordUP, this.MaxRecordsUP, this.CapabilityFilterTB, m_configuration);
+                    m_server = null;
+                    OkBTN.Enabled = false;
+                }
+            }
+            catch (Exception exception)
+            {
+                GuiUtils.HandleException(this.Text, MethodBase.GetCurrentMethod(), exception);
+            }
+        }
+
+        private void HostNameCTRL_HostConnected(object sender, SelectHostCtrlEventArgs e)
+        {
+            try
+            {
+                m_hostname = e.Hostname;
+                ServersCTRL.Initialize(m_hostname, this.StartingRecordUP, this.MaxRecordsUP, this.CapabilityFilterTB, m_configuration);
+                m_server = null;
+                OkBTN.Enabled = false;
+            }
+            catch (Exception exception)
+            {
+                GuiUtils.HandleException(this.Text, MethodBase.GetCurrentMethod(), exception);
+            }
+        }
+
+        private void ServersCTRL_ItemsSelected(object sender, ListItemActionEventArgs e)
+        {
+            try
+            {
+                m_server = null;
+
+                foreach (ServerOnNetwork server in e.Items)
+                {
+                    m_server = server;
+                    break;
+                }
+
+                OkBTN.Enabled = m_server != null;
+            }
+            catch (Exception exception)
+            {
+                GuiUtils.HandleException(this.Text, MethodBase.GetCurrentMethod(), exception);
+            }
+        }
+
+        private void ServersCTRL_ItemsPicked(object sender, ListItemActionEventArgs e)
+        {
+            try
+            {
+                m_server = null;
+
+                foreach (ServerOnNetwork server in e.Items)
+                {
+                    m_server = server;
+                    break;
+                }
+
+                if (m_server != null)
+                {
+                    DialogResult = DialogResult.OK;
+                }
+            }
+            catch (Exception exception)
+            {
+                GuiUtils.HandleException(this.Text, MethodBase.GetCurrentMethod(), exception);
+            }
+        }
+        #endregion
+    }
+}

--- a/SampleApplications/Samples/ClientControls.Net4/Common/DiscoveredServerOnNetworkListDlg.resx
+++ b/SampleApplications/Samples/ClientControls.Net4/Common/DiscoveredServerOnNetworkListDlg.resx
@@ -117,10 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="MainMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="StatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>229, 17</value>
-  </metadata>
 </root>

--- a/SampleApplications/Samples/ClientControls.Net4/UA Client Controls.csproj
+++ b/SampleApplications/Samples/ClientControls.Net4/UA Client Controls.csproj
@@ -388,6 +388,18 @@
     <Compile Include="Common\Client\WriteRequestListViewCtrl.Designer.cs">
       <DependentUpon>WriteRequestListViewCtrl.cs</DependentUpon>
     </Compile>
+    <Compile Include="Common\DiscoveredServerOnNetworkListCtrl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Common\DiscoveredServerOnNetworkListCtrl.designer.cs">
+      <DependentUpon>DiscoveredServerOnNetworkListCtrl.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Common\DiscoveredServerOnNetworkListDlg.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Common\DiscoveredServerOnNetworkListDlg.designer.cs">
+      <DependentUpon>DiscoveredServerOnNetworkListDlg.cs</DependentUpon>
+    </Compile>
     <Compile Include="Common\SelectHostCtrl.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -840,6 +852,12 @@
     <EmbeddedResource Include="Common\Client\WriteRequestListViewCtrl.resx">
       <DependentUpon>WriteRequestListViewCtrl.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Common\DiscoveredServerOnNetworkListCtrl.resx">
+      <DependentUpon>DiscoveredServerOnNetworkListCtrl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Common\DiscoveredServerOnNetworkListDlg.resx">
+      <DependentUpon>DiscoveredServerOnNetworkListDlg.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Common\SelectHostCtrl.resx">
       <DependentUpon>SelectHostCtrl.cs</DependentUpon>

--- a/SampleApplications/Samples/Controls.Net4/ClientForm.Designer.cs
+++ b/SampleApplications/Samples/Controls.Net4/ClientForm.Designer.cs
@@ -84,11 +84,14 @@ namespace Opc.Ua.Sample.Controls
             this.NotificationsCTRL = new Opc.Ua.Sample.Controls.NotificationMessageListCtrl();
             this.EndpointSelectorCTRL = new Opc.Ua.Client.Controls.EndpointSelectorCtrl();
             this.serverHeaderBranding1 = new Opc.Ua.Server.Controls.ServerHeaderBranding();
+            this.DiscoveryServersOnNetworkMI = new System.Windows.Forms.ToolStripMenuItem();
             this.MainMenu.SuspendLayout();
             this.StatusStrip.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.MainPN)).BeginInit();
             this.MainPN.Panel1.SuspendLayout();
             this.MainPN.Panel2.SuspendLayout();
             this.MainPN.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.SessionsPanel)).BeginInit();
             this.SessionsPanel.Panel1.SuspendLayout();
             this.SessionsPanel.Panel2.SuspendLayout();
             this.SessionsPanel.SuspendLayout();
@@ -116,36 +119,36 @@ namespace Opc.Ua.Sample.Controls
             this.toolStripMenuItem1,
             this.FileExit});
             this.FileMI.Name = "FileMI";
-            this.FileMI.Size = new System.Drawing.Size(35, 20);
+            this.FileMI.Size = new System.Drawing.Size(37, 20);
             this.FileMI.Text = "File";
             // 
             // FileLoadMI
             // 
             this.FileLoadMI.Name = "FileLoadMI";
-            this.FileLoadMI.Size = new System.Drawing.Size(125, 22);
+            this.FileLoadMI.Size = new System.Drawing.Size(123, 22);
             this.FileLoadMI.Text = "Load...";
             // 
             // FileSaveMI
             // 
             this.FileSaveMI.Name = "FileSaveMI";
-            this.FileSaveMI.Size = new System.Drawing.Size(125, 22);
+            this.FileSaveMI.Size = new System.Drawing.Size(123, 22);
             this.FileSaveMI.Text = "Save";
             // 
             // FileSaveAsMI
             // 
             this.FileSaveAsMI.Name = "FileSaveAsMI";
-            this.FileSaveAsMI.Size = new System.Drawing.Size(125, 22);
+            this.FileSaveAsMI.Size = new System.Drawing.Size(123, 22);
             this.FileSaveAsMI.Text = "Save As...";
             // 
             // toolStripMenuItem1
             // 
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(122, 6);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(120, 6);
             // 
             // FileExit
             // 
             this.FileExit.Name = "FileExit";
-            this.FileExit.Size = new System.Drawing.Size(125, 22);
+            this.FileExit.Size = new System.Drawing.Size(123, 22);
             this.FileExit.Text = "Exit";
             this.FileExit.Click += new System.EventHandler(this.FileExit_Click);
             // 
@@ -157,32 +160,32 @@ namespace Opc.Ua.Sample.Controls
             this.toolStripSeparator1,
             this.Task_TestMI});
             this.TaskMI.Name = "TaskMI";
-            this.TaskMI.Size = new System.Drawing.Size(41, 20);
+            this.TaskMI.Size = new System.Drawing.Size(42, 20);
             this.TaskMI.Text = "Task";
             // 
             // NewWindowMI
             // 
             this.NewWindowMI.Name = "NewWindowMI";
-            this.NewWindowMI.Size = new System.Drawing.Size(148, 22);
+            this.NewWindowMI.Size = new System.Drawing.Size(154, 22);
             this.NewWindowMI.Text = "New Window...";
             this.NewWindowMI.Click += new System.EventHandler(this.NewWindowMI_Click);
             // 
             // PerformanceTestMI
             // 
             this.PerformanceTestMI.Name = "PerformanceTestMI";
-            this.PerformanceTestMI.Size = new System.Drawing.Size(148, 22);
+            this.PerformanceTestMI.Size = new System.Drawing.Size(154, 22);
             this.PerformanceTestMI.Text = "Stack Test...";
             this.PerformanceTestMI.Click += new System.EventHandler(this.PerformanceTestMI_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(145, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(151, 6);
             // 
             // Task_TestMI
             // 
             this.Task_TestMI.Name = "Task_TestMI";
-            this.Task_TestMI.Size = new System.Drawing.Size(148, 22);
+            this.Task_TestMI.Size = new System.Drawing.Size(154, 22);
             this.Task_TestMI.Text = "Test 1";
             this.Task_TestMI.Click += new System.EventHandler(this.Task_TestMI_Click);
             // 
@@ -190,22 +193,23 @@ namespace Opc.Ua.Sample.Controls
             // 
             this.DiscoveyrMI.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.DiscoverServersMI,
+            this.DiscoveryServersOnNetworkMI,
             this.Discovery_RegisterMI});
             this.DiscoveyrMI.Name = "DiscoveyrMI";
-            this.DiscoveyrMI.Size = new System.Drawing.Size(66, 20);
+            this.DiscoveyrMI.Size = new System.Drawing.Size(70, 20);
             this.DiscoveyrMI.Text = "Discovery";
             // 
             // DiscoverServersMI
             // 
             this.DiscoverServersMI.Name = "DiscoverServersMI";
-            this.DiscoverServersMI.Size = new System.Drawing.Size(138, 22);
+            this.DiscoverServersMI.Size = new System.Drawing.Size(185, 22);
             this.DiscoverServersMI.Text = "Servers...";
             this.DiscoverServersMI.Click += new System.EventHandler(this.DiscoverServersMI_Click);
             // 
             // Discovery_RegisterMI
             // 
             this.Discovery_RegisterMI.Name = "Discovery_RegisterMI";
-            this.Discovery_RegisterMI.Size = new System.Drawing.Size(138, 22);
+            this.Discovery_RegisterMI.Size = new System.Drawing.Size(185, 22);
             this.Discovery_RegisterMI.Text = "Register Now";
             this.Discovery_RegisterMI.Click += new System.EventHandler(this.Discovery_RegisterMI_Click);
             // 
@@ -214,13 +218,13 @@ namespace Opc.Ua.Sample.Controls
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.contentsToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(40, 20);
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
             this.helpToolStripMenuItem.Text = "&Help";
             // 
             // contentsToolStripMenuItem
             // 
             this.contentsToolStripMenuItem.Name = "contentsToolStripMenuItem";
-            this.contentsToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.contentsToolStripMenuItem.Size = new System.Drawing.Size(122, 22);
             this.contentsToolStripMenuItem.Text = "&Contents";
             this.contentsToolStripMenuItem.Click += new System.EventHandler(this.contentsToolStripMenuItem_Click);
             // 
@@ -238,13 +242,13 @@ namespace Opc.Ua.Sample.Controls
             // ServerUrlLB
             // 
             this.ServerUrlLB.Name = "ServerUrlLB";
-            this.ServerUrlLB.Size = new System.Drawing.Size(71, 17);
+            this.ServerUrlLB.Size = new System.Drawing.Size(79, 17);
             this.ServerUrlLB.Text = "Disconnected";
             // 
             // ServerStatusLB
             // 
             this.ServerStatusLB.Name = "ServerStatusLB";
-            this.ServerStatusLB.Size = new System.Drawing.Size(51, 17);
+            this.ServerStatusLB.Size = new System.Drawing.Size(49, 17);
             this.ServerStatusLB.Text = "00:00:00";
             // 
             // MainPN
@@ -329,8 +333,8 @@ namespace Opc.Ua.Sample.Controls
             this.EndpointSelectorCTRL.SelectedEndpoint = null;
             this.EndpointSelectorCTRL.Size = new System.Drawing.Size(553, 27);
             this.EndpointSelectorCTRL.TabIndex = 2;
-            this.EndpointSelectorCTRL.EndpointsChanged += new System.EventHandler(this.EndpointSelectorCTRL_OnChange);
             this.EndpointSelectorCTRL.ConnectEndpoint += new Opc.Ua.Client.Controls.ConnectEndpointEventHandler(this.EndpointSelectorCTRL_ConnectEndpoint);
+            this.EndpointSelectorCTRL.EndpointsChanged += new System.EventHandler(this.EndpointSelectorCTRL_OnChange);
             // 
             // serverHeaderBranding1
             // 
@@ -344,6 +348,13 @@ namespace Opc.Ua.Sample.Controls
             this.serverHeaderBranding1.Padding = new System.Windows.Forms.Padding(3);
             this.serverHeaderBranding1.Size = new System.Drawing.Size(553, 90);
             this.serverHeaderBranding1.TabIndex = 9;
+            // 
+            // DiscoveryServersOnNetworkMI
+            // 
+            this.DiscoveryServersOnNetworkMI.Name = "DiscoveryServersOnNetworkMI";
+            this.DiscoveryServersOnNetworkMI.Size = new System.Drawing.Size(185, 22);
+            this.DiscoveryServersOnNetworkMI.Text = "Servers on Network...";
+            this.DiscoveryServersOnNetworkMI.Click += new System.EventHandler(this.DiscoveryServersOnNetworkMI_Click);
             // 
             // ClientForm
             // 
@@ -365,9 +376,11 @@ namespace Opc.Ua.Sample.Controls
             this.StatusStrip.PerformLayout();
             this.MainPN.Panel1.ResumeLayout(false);
             this.MainPN.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.MainPN)).EndInit();
             this.MainPN.ResumeLayout(false);
             this.SessionsPanel.Panel1.ResumeLayout(false);
             this.SessionsPanel.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.SessionsPanel)).EndInit();
             this.SessionsPanel.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -403,5 +416,6 @@ namespace Opc.Ua.Sample.Controls
         private Opc.Ua.Server.Controls.ServerHeaderBranding serverHeaderBranding1;
         private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem contentsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem DiscoveryServersOnNetworkMI;
     }
 }

--- a/SampleApplications/Samples/Controls.Net4/ClientForm.cs
+++ b/SampleApplications/Samples/Controls.Net4/ClientForm.cs
@@ -391,6 +391,32 @@ namespace Opc.Ua.Sample.Controls
             }
         }
 
+        private void DiscoveryServersOnNetworkMI_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                ServerOnNetwork serverOnNetwork = new DiscoveredServerOnNetworkListDlg().ShowDialog(null, m_configuration);
+
+                if (serverOnNetwork != null)
+                {
+                    ApplicationDescription server = new ApplicationDescription();
+                    server.ApplicationName = serverOnNetwork.ServerName;
+                    server.DiscoveryUrls.Add(serverOnNetwork.DiscoveryUrl);
+
+                    ConfiguredEndpoint endpoint = new ConfiguredEndpoint(server, EndpointConfiguration.Create(m_configuration));
+
+                    this.EndpointSelectorCTRL.SelectedEndpoint = endpoint;
+
+                    return;
+                }
+            }
+            catch (Exception exception)
+            {
+                GuiUtils.HandleException(this.Text, MethodBase.GetCurrentMethod(), exception);
+            }
+
+        }
+
         private void NewWindowMI_Click(object sender, EventArgs e)
         {
             try
@@ -458,5 +484,6 @@ namespace Opc.Ua.Sample.Controls
                 MessageBox.Show("Unable to launch help documentation. Error: " + ex.Message);
             }
         }
+
     }
 }

--- a/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/DiscoveryClient.cs
@@ -93,6 +93,34 @@ namespace Opc.Ua
 
             return servers;
         }
+
+        /// <summary>
+        /// Invokes the FindServersOnNetwork service.
+        /// </summary>
+        /// <param name="startingRecordId"></param>
+        /// <param name="maxRecordsToReturn"></param>
+        /// <param name="serverCapabilityFilter"></param>
+        /// <param name="lastCounterResetTime"></param>
+        /// <returns></returns>
+        public virtual ServerOnNetworkCollection FindServersOnNetwork(
+            uint startingRecordId,
+            uint maxRecordsToReturn,
+            StringCollection serverCapabilityFilter,
+            out DateTime lastCounterResetTime)
+        {
+            ServerOnNetworkCollection servers = null;
+
+            FindServersOnNetwork(
+                null,
+                startingRecordId,
+                maxRecordsToReturn,
+                serverCapabilityFilter,
+                out lastCounterResetTime,
+                out servers);
+
+            return servers;
+        }
+
         #endregion  
     }
     


### PR DESCRIPTION
RegisterServer2() is called as first option for LDS registration of the server.
The ClientControls was extended to use FindServersonNetwork() into the LDS-ME for discovering the OPC UA Servers announcing themselves using Bonjour services.