### PR TITLE
fix an exception on Linux when the /private cert folder doesn't exist

### DIFF
--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -723,7 +723,8 @@ namespace Opc.Ua
                 }
 
                 // check if cache is still good.
-                if (m_certificateSubdir.LastWriteTimeUtc < m_lastDirectoryCheck && (NoPrivateKeys || this.m_privateKeySubdir.LastWriteTimeUtc < m_lastDirectoryCheck))
+                if ((m_certificateSubdir.LastWriteTimeUtc < m_lastDirectoryCheck) && 
+                    (NoPrivateKeys || !m_privateKeySubdir.Exists || m_privateKeySubdir.LastWriteTimeUtc < m_lastDirectoryCheck))
                 {
                     return m_certificates;
                 }


### PR DESCRIPTION
fix for https://github.com/OPCFoundation/UA-.NETStandardLibrary/issues/112