### PR TITLE
Rework Task.Run( async to reduce threadpool usage

### DIFF
--- a/ComIOP/Common/Proxy/OpcProxyUtils.cs
+++ b/ComIOP/Common/Proxy/OpcProxyUtils.cs
@@ -57,8 +57,7 @@ namespace Opc.Ua.Com
             }
 
             // check for certificate with a private key.
-            X509Certificate2 certificate = null;
-            Task.Run(async () => certificate = await id.Find(true)).Wait();
+            X509Certificate2 certificate = id.Find(true).Result;
 
             if (certificate != null)
             {
@@ -94,15 +93,11 @@ namespace Opc.Ua.Com
 
             try
             {
-                Task.Run(async () =>
+                    X509Certificate2Collection certificateCollection = store.FindByThumbprint(certificate.Thumbprint).Result;
+                    if (certificateCollection != null)
                     {
-                        X509Certificate2Collection certificateCollection = await store.FindByThumbprint(certificate.Thumbprint);
-                        if (certificateCollection != null)
-                        {
-                            await store.Add(certificateCollection[0]);
-                        }
+                        store.Add(certificateCollection[0]).Wait();
                     }
-                ).Wait();
             }
             finally
             {
@@ -120,7 +115,7 @@ namespace Opc.Ua.Com
         public static ApplicationConfiguration ApplicationConfigurationLoad(string sectionName, ApplicationType applicationType)
         {
             ApplicationConfiguration config = null;
-            Task.Run(async () => config = await ApplicationConfiguration.Load(sectionName, applicationType)).Wait();
+            config = ApplicationConfiguration.Load(sectionName, applicationType).Result;
             return config;
         }
 

--- a/ComIOP/Wrapper/ServerWrapper/Program.cs
+++ b/ComIOP/Wrapper/ServerWrapper/Program.cs
@@ -50,8 +50,7 @@ namespace Opc.Ua.Com.Client
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-            Task.Run(async () => await AsyncMain()).Wait();
-
+            AsyncMain().Wait();
         }
 
         /// <summary>

--- a/SampleApplications/SDK/Opc.Ua.Client/Session.cs
+++ b/SampleApplications/SDK/Opc.Ua.Client/Session.cs
@@ -171,11 +171,8 @@ namespace Opc.Ua.Client
                             "The client configuration does not specify an application instance certificate.");
                     }
 
-                    Task t = Task.Run( async () =>
-                    {
-                        m_instanceCertificate = await m_configuration.SecurityConfiguration.ApplicationCertificate.Find(true);
-                    });
-                    t.Wait();
+                    m_instanceCertificate = m_configuration.SecurityConfiguration.ApplicationCertificate.Find(true).Result;
+
                 }
 
                 // check for valid certificate.
@@ -202,11 +199,7 @@ namespace Opc.Ua.Client
                 // load certificate chain
                 m_instanceCertificateChain = new X509Certificate2Collection(m_instanceCertificate);
                 List<CertificateIdentifier> issuers = new List<CertificateIdentifier>();
-                Task t2 = Task.Run(async () =>
-                {
-                    await configuration.CertificateValidator.GetIssuers(m_instanceCertificate, issuers);
-                });
-                t2.Wait();
+                configuration.CertificateValidator.GetIssuers(m_instanceCertificate, issuers).Wait();
 
                 for (int i = 0; i < issuers.Count; i++)
                 {

--- a/SampleApplications/SDK/Opc.Ua.Client/project.json
+++ b/SampleApplications/SDK/Opc.Ua.Client/project.json
@@ -1,14 +1,17 @@
 {
-    "version": "1.0.0-*",
+  "version": "1.0.0-*",
 
-    "dependencies": {
-        "NETStandard.Library": "1.6.0",
-        "Opc.Ua.Core": "1.0.0-*"
-    },
+  "dependencies": {
+    "NETStandard.Library": "1.6.0",
+    "Opc.Ua.Core": "1.0.0-*"
+  },
 
-    "frameworks": {
-        "net46": {},
-        "netstandard1.3": {},
-        "uap10.0": {}
-    }
+  "frameworks": {
+    "net46": {},
+    "netstandard1.3": {},
+    "uap10.0": {}
+  },
+
+  "debugType": "portable"
+
 }

--- a/SampleApplications/SDK/Opc.Ua.Configuration/project.json
+++ b/SampleApplications/SDK/Opc.Ua.Configuration/project.json
@@ -1,14 +1,16 @@
 {
-    "version": "1.0.0-*",
+  "version": "1.0.0-*",
 
-    "dependencies": {
-        "NETStandard.Library": "1.6.0",
-        "Opc.Ua.Core": "1.0.0-*"
-    },
+  "dependencies": {
+    "NETStandard.Library": "1.6.0",
+    "Opc.Ua.Core": "1.0.0-*"
+  },
 
-    "frameworks": {
-        "net46": {},
-        "netstandard1.3": {},
-        "uap10.0": {}
-    }
+  "frameworks": {
+    "net46": {},
+    "netstandard1.3": {},
+    "uap10.0": {}
+  },
+
+  "debugType": "portable"
 }

--- a/SampleApplications/SDK/Opc.Ua.Server/project.json
+++ b/SampleApplications/SDK/Opc.Ua.Server/project.json
@@ -14,5 +14,7 @@
         "define": [ "NO_HTTPS" ]
       }
     }
-  }
+  },
+
+  "debugType": "portable"
 }

--- a/SampleApplications/Samples/Client.Net4/Program.cs
+++ b/SampleApplications/Samples/Client.Net4/Program.cs
@@ -58,21 +58,17 @@ namespace Opc.Ua.Sample
 
             try
             {
-                Task<ApplicationConfiguration> task = application.LoadApplicationConfiguration(false);
-                task.Wait();
+                application.LoadApplicationConfiguration(false).Wait();
 
                 // check the application certificate.
-                Task<bool> task2 = application.CheckApplicationInstanceCertificate(false, 0);
-                task2.Wait();
-                bool certOK = task2.Result;
+                bool certOK = application.CheckApplicationInstanceCertificate(false, 0).Result;
                 if (!certOK)
                 {
                     throw new Exception("Application instance certificate invalid!");
                 }
 
                 // start the server.
-                Task task3 = application.Start(new SampleServer());
-                task3.Wait();
+                application.Start(new SampleServer()).Wait();
 
                 // run the application interactively.
                 Application.Run(new SampleClientForm(application, null, application.ApplicationConfiguration));

--- a/SampleApplications/Samples/ClientControls.Net4/Configuration/CertificateListDlg.cs
+++ b/SampleApplications/Samples/ClientControls.Net4/Configuration/CertificateListDlg.cs
@@ -159,7 +159,7 @@ namespace Opc.Ua.Client.Controls
                 CertificateStoreIdentifier store = new CertificateStoreIdentifier();
                 store.StoreType = CertificateStoreCTRL.StoreType;
                 store.StorePath = CertificateStoreCTRL.StorePath;
-                Task.Run( async () => await CertificatesCTRL.Initialize(store, null)).Wait();
+                CertificatesCTRL.Initialize(store, null).Wait();
 
                 FilterBTN_Click(sender, e);
             }

--- a/SampleApplications/Samples/ClientControls.Net4/Configuration/CertificateStoreTreeCtrl.cs
+++ b/SampleApplications/Samples/ClientControls.Net4/Configuration/CertificateStoreTreeCtrl.cs
@@ -166,7 +166,7 @@ namespace Opc.Ua.Client.Controls
 
             if (m_certificateListCtrl != null)
             {
-                Task.Run( async () => await m_certificateListCtrl.Initialize(SelectedStore, null)).Wait();
+                m_certificateListCtrl.Initialize(SelectedStore, null).Wait();
             }
         }
 

--- a/SampleApplications/Samples/NetCoreConsoleServer/Program.cs
+++ b/SampleApplications/Samples/NetCoreConsoleServer/Program.cs
@@ -80,8 +80,7 @@ namespace NetCoreConsoleServer
 
             try
             {
-                Task t = ConsoleSampleServer();
-                t.Wait();
+                ConsoleSampleServer().Wait();
                 Console.WriteLine("Server started. Press any key to exit...");
             }
             catch (Exception ex)

--- a/SampleApplications/Samples/Opc.Ua.Sample/project.json
+++ b/SampleApplications/Samples/Opc.Ua.Sample/project.json
@@ -13,6 +13,8 @@
     "uap10.0": {}
   },
 
+  "debugType": "portable",
+
   "buildOptions": {
     "embed": {
       "includeFiles": [

--- a/SampleApplications/Workshop/Aggregation/Client/Program.cs
+++ b/SampleApplications/Workshop/Aggregation/Client/Program.cs
@@ -54,10 +54,10 @@ namespace AggregationClient
             try
             {
                 // load the application configuration.
-                Task.Run( async () => await application.LoadApplicationConfiguration(false)).Wait();
+                application.LoadApplicationConfiguration(false).Wait();
 
                 // check the application certificate.
-                Task.Run( async () => await application.CheckApplicationInstanceCertificate(false, 0)).Wait();
+                application.CheckApplicationInstanceCertificate(false, 0).Wait();
 
                 // run the application interactively.
                 Application.Run(new MainForm(application.ApplicationConfiguration));

--- a/SampleApplications/Workshop/Aggregation/Server/AggregationNodeManager.cs
+++ b/SampleApplications/Workshop/Aggregation/Server/AggregationNodeManager.cs
@@ -1152,18 +1152,15 @@ namespace AggregationServer
 
             try
             {
-                Task.Run(async () =>
-                    {
-                        session = await Opc.Ua.Client.Session.Create(
-                            m_configuration,
-                            m_endpoint,
-                            (context == null),
-                            sessionName,
-                            60000,
-                            userIdentity,
-                            preferredLocales);
-                    }
-                ).Wait();
+                
+                session = Opc.Ua.Client.Session.Create(
+                    m_configuration,
+                    m_endpoint,
+                    (context == null),
+                    sessionName,
+                    60000,
+                    userIdentity,
+                    preferredLocales).Result;
 
                 m_clients.Add(sessionId, session);
 

--- a/SampleApplications/Workshop/Aggregation/Server/Program.cs
+++ b/SampleApplications/Workshop/Aggregation/Server/Program.cs
@@ -46,7 +46,7 @@ namespace AggregationServer
         [STAThread]
         static void Main()
         {
-            Task.Run(async () => await MyMain()).Wait();
+            MyMain().Wait();
         }
         static async Task MyMain()
         {

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -180,13 +180,11 @@ namespace Opc.Ua
 
             try
             {
-                Task.Run(async () =>
-                {
-                    await InternalValidate(chain);
-                }).Wait();
-
                 lock (m_lock)
-                { 
+                {
+
+                    InternalValidate(chain).Wait();
+
                     // add to list of validated certificates.
                     m_validatedCertificates[certificate.Thumbprint] = certificate;
                 }

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -620,7 +620,7 @@ namespace Opc.Ua
 
             X509Certificate2 issuer = null;
             X509Certificate2Collection certificates = null;
-            Task.Run( async () => certificates = await Enumerate()).Wait();
+            certificates = Enumerate().Result;
             foreach (X509Certificate2 certificate in certificates)
             {
                 if (Utils.CompareDistinguishedName(certificate.Subject, crl.Issuer))

--- a/Stack/Opc.Ua.Core/Stack/Client/UserIdentity.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/UserIdentity.cs
@@ -62,9 +62,7 @@ namespace Opc.Ua
         {
             if (certificateId == null) throw new ArgumentNullException("certificateId");
 
-            Task<X509Certificate2> task = certificateId.Find();
-            task.Wait();
-            X509Certificate2 certificate = task.Result;
+            X509Certificate2 certificate = certificateId.Find().Result;
             if (certificate != null)
             {
                 Initialize(certificate);

--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -1275,11 +1275,7 @@ namespace Opc.Ua
             // load the instance certificate.
             if (configuration.SecurityConfiguration.ApplicationCertificate != null)
             {
-                Task t = Task.Run(async () =>
-                {
-                    InstanceCertificate = await configuration.SecurityConfiguration.ApplicationCertificate.Find(true);
-                });
-                t.Wait();
+                InstanceCertificate = configuration.SecurityConfiguration.ApplicationCertificate.Find(true).Result;
             }
 
             if (InstanceCertificate == null)

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpClientChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpClientChannel.cs
@@ -101,7 +101,7 @@ namespace Opc.Ua.Bindings
             if (url == null) throw new ArgumentNullException("url");
             if (timeout <= 0) throw new ArgumentException("Timeout must be greater than zero.", "timeout");
 
-            Task t;
+            Task task;
             lock (DataLock)
             {
                 if (State != TcpChannelState.Closed)
@@ -127,13 +127,10 @@ namespace Opc.Ua.Bindings
                 State = TcpChannelState.Connecting;
                 Socket = new TcpMessageSocket(this, BufferManager, Quotas.MaxBufferSize);
 
-                t = Task.Run(async () =>
-                {
-                    await Socket.BeginConnect(m_via, m_ConnectCallback, operation);
-                });
+                task = Socket.BeginConnect(m_via, m_ConnectCallback, operation);
             }
 
-            t.Wait();
+            task.Wait();
 
             return m_handshakeOperation;
         }
@@ -770,7 +767,7 @@ namespace Opc.Ua.Bindings
             {
                 Utils.Trace("Channel {0}: Scheduled Handshake Starting: TokenId={1}", ChannelId, CurrentToken.TokenId);
 
-                Task t;
+                Task task;
                 lock (DataLock)
                 {
                     // check if renewing a token.
@@ -824,12 +821,9 @@ namespace Opc.Ua.Bindings
 
                     State = TcpChannelState.Connecting;
                     Socket = new TcpMessageSocket(this, BufferManager, Quotas.MaxBufferSize);
-                    t = Task.Run(async () =>
-                    {
-                        await Socket.BeginConnect(m_via, m_ConnectCallback, m_handshakeOperation);
-                    });
+                    task = Socket.BeginConnect(m_via, m_ConnectCallback, m_handshakeOperation);
                 }
-                t.Wait();
+                task.Wait();
             }
             catch (Exception e)
             {

--- a/Stack/Opc.Ua.Core/project.json
+++ b/Stack/Opc.Ua.Core/project.json
@@ -39,8 +39,10 @@
       "includeFiles": [
         "Stack/Generated/Opc.Ua.PredefinedNodes.uanodes",
         "Types/Utils/LocalizedData.txt"
-      ] 
+      ]
     }
-  }
+  },
+
+  "debugType": "portable"
 
 }


### PR DESCRIPTION
Many Task.Run() with async lambdas are removed to reduce the number of blocked threads. This rework fixes a deadlock on Linux caused by the threadpool to running out of free threads when security tokens are renewed.

Fixes the issue https://github.com/OPCFoundation/UA-.NETStandardLibrary/issues/115

