### PR TITLE
Cert fixes

### DIFF
--- a/SampleApplications/Samples/NetCoreConsoleClient/Properties/launchSettings.json
+++ b/SampleApplications/Samples/NetCoreConsoleClient/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "NetCoreConsoleClient": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COMPlus_ReadyToRunExcludeList": "System.Security.Cryptography.X509Certificates"
+      }
+    }
+  }
+}

--- a/SampleApplications/Samples/NetCoreConsoleServer/Properties/launchSettings.json
+++ b/SampleApplications/Samples/NetCoreConsoleServer/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "NetCoreConsoleServer": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "Key": "Value",
+        "COMPlus_ReadyToRunExcludeList": "System.Security.Cryptography.X509Certificates"
+      }
+    }
+  }
+}

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateFactory.cs
@@ -224,7 +224,7 @@ namespace Opc.Ua
 
             var nameValues = new ArrayList();
             nameValues.Add(domainNames[0]);
-            nameValues.Add(applicationName);
+            nameValues.Add(subjectName);
 
             // self signed 
             X509Name subjectDN = new X509Name(nameOids, nameValues);
@@ -480,7 +480,7 @@ namespace Opc.Ua
             // create the subject name,
             if (String.IsNullOrEmpty(subjectName))
             {
-                subjectName = Utils.Format("CN={0}/DC={1}", applicationName, domainNames[0]);
+                subjectName = applicationName;
             }
         }
         #endregion


### PR DESCRIPTION
Fix: https://github.com/OPCFoundation/UA-.NETStandardLibrary/issues/104
Workaround: https://github.com/OPCFoundation/UA-.NETStandardLibrary/issues/103

-Workaround for https://github.com/dotnet/corefx/issues/12412 

On .Net Core 1.1 set environment
set COMPlus_ReadyToRunExcludeList=System.Security.Cryptography.X509Certificates

