### PR TITLE
Change the port number to the standard OPC-UA port 4840

### DIFF
--- a/SampleApplications/Samples/Client.Net4/Opc.Ua.SampleClient.Endpoints.xml
+++ b/SampleApplications/Samples/Client.Net4/Opc.Ua.SampleClient.Endpoints.xml
@@ -37,10 +37,10 @@
 
     <!-- 
       Sample server, opc.tcp endpoint:
-        opc.tcp://localhost:51210/UA/SampleServer // -->
+        opc.tcp://localhost:4840/UA/SampleServer // -->
     <ua:ConfiguredEndpoint>
       <ua:Endpoint>
-        <EndpointUrl>opc.tcp://localhost:51210/UA/SampleServer</EndpointUrl>
+        <EndpointUrl>opc.tcp://localhost:4840/UA/SampleServer</EndpointUrl>
         <SecurityMode>SignAndEncrypt_3</SecurityMode>
         <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15</SecurityPolicyUri>
         <UserIdentityTokens>

--- a/SampleApplications/Samples/Client/Opc.Ua.SampleClient.Endpoints.xml
+++ b/SampleApplications/Samples/Client/Opc.Ua.SampleClient.Endpoints.xml
@@ -38,10 +38,10 @@
 
     <!-- 
       Sample server, opc.tcp endpoint:
-        opc.tcp://localhost:51210/UA/SampleServer // -->
+        opc.tcp://localhost:4840/UA/SampleServer // -->
     <ua:ConfiguredEndpoint>
       <ua:Endpoint>
-        <EndpointUrl>opc.tcp://localhost:51210/UA/SampleServer</EndpointUrl>
+        <EndpointUrl>opc.tcp://localhost:4840/UA/SampleServer</EndpointUrl>
         <SecurityMode>SignAndEncrypt_3</SecurityMode>
         <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15</SecurityPolicyUri>
         <UserIdentityTokens>

--- a/SampleApplications/Samples/NetCoreConsoleClient/Program.cs
+++ b/SampleApplications/Samples/NetCoreConsoleClient/Program.cs
@@ -28,7 +28,7 @@ namespace NetCoreConsoleClient
             if (args.Length == 0)
             {
                 // use OPC UA .Net Sample server 
-                endpointURL = "opc.tcp://" + Utils.GetHostName() + ":51210/UA/SampleServer";
+                endpointURL = "opc.tcp://" + Utils.GetHostName() + ":4840/UA/SampleServer";
             }
             else
             {

--- a/SampleApplications/Samples/NetCoreConsoleServer/Opc.Ua.SampleServer.Config.xml
+++ b/SampleApplications/Samples/NetCoreConsoleServer/Opc.Ua.SampleServer.Config.xml
@@ -57,7 +57,7 @@
   
   <ServerConfiguration>
     <BaseAddresses>
-      <ua:String>opc.tcp://localhost:51210/UA/SampleServer</ua:String>
+      <ua:String>opc.tcp://localhost:4840/UA/SampleServer</ua:String>
       <ua:String>https://localhost:51212/UA/SampleServer/</ua:String>
     </BaseAddresses>
 

--- a/SampleApplications/Samples/Server.Net4/Opc.Ua.SampleServer.Config.xml
+++ b/SampleApplications/Samples/Server.Net4/Opc.Ua.SampleServer.Config.xml
@@ -54,7 +54,7 @@
   
   <ServerConfiguration>
     <BaseAddresses>
-      <ua:String>opc.tcp://localhost:51210/UA/SampleServer</ua:String>
+      <ua:String>opc.tcp://localhost:4840/UA/SampleServer</ua:String>
       <ua:String>https://localhost:51212/UA/SampleServer/</ua:String>
     </BaseAddresses>
 

--- a/SampleApplications/Samples/Server/Opc.Ua.SampleServer.Config.xml
+++ b/SampleApplications/Samples/Server/Opc.Ua.SampleServer.Config.xml
@@ -54,7 +54,7 @@
   
   <ServerConfiguration>
     <BaseAddresses>
-      <ua:String>opc.tcp://localhost:51210/UA/SampleServer</ua:String>
+      <ua:String>opc.tcp://localhost:4840/UA/SampleServer</ua:String>
     </BaseAddresses>
 
     <!-- 

--- a/SampleApplications/Workshop/Aggregation/ConsoleAggregationServer/Quickstarts.AggregationServer.Config.xml
+++ b/SampleApplications/Workshop/Aggregation/ConsoleAggregationServer/Quickstarts.AggregationServer.Config.xml
@@ -191,7 +191,7 @@
         <ua:Endpoints>
           <ua:ConfiguredEndpoint>
             <ua:Endpoint>
-              <EndpointUrl>opc.tcp://localhost:51210/UA/SampleServer</EndpointUrl>
+              <EndpointUrl>opc.tcp://localhost:4840/UA/SampleServer</EndpointUrl>
               <SecurityMode>SignAndEncrypt_3</SecurityMode>
               <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15</SecurityPolicyUri>
               <UserIdentityTokens>

--- a/SampleApplications/Workshop/Aggregation/Server/Quickstarts.AggregationServer.Config.xml
+++ b/SampleApplications/Workshop/Aggregation/Server/Quickstarts.AggregationServer.Config.xml
@@ -164,7 +164,7 @@
         <ua:Endpoints>
           <ua:ConfiguredEndpoint>
             <ua:Endpoint>
-              <EndpointUrl>opc.tcp://localhost:51210/UA/SampleServer</EndpointUrl>
+              <EndpointUrl>opc.tcp://localhost:4840/UA/SampleServer</EndpointUrl>
               <SecurityMode>SignAndEncrypt_3</SecurityMode>
               <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15</SecurityPolicyUri>
               <UserIdentityTokens>


### PR DESCRIPTION
From https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=4840
   opcua-tcp   4840    tcp OPC UA TCP Protocol
   opcua-udp   4840    udp OPC UA TCP Protocol
51210 is in the ephemeral port range, so may already be in use by TCP for another purpose.
Also, a web search reveals other applications (Dialpad and Xsan Filesystem Access) already (mis)use that port
also, so it quite likely to conflict on some networks and be misclassified by monitoring tools, router ACLs, etc.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>