### PR TITLE
fix Security Certificate Validation / test 010

### DIFF
--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -817,12 +817,12 @@ namespace Opc.Ua
 
                 case X509ChainStatusFlags.UntrustedRoot:
                     {
-                        // check if a self signed cert is valid
+                        // self signed cert signature validation 
+                        // .Net Core ChainStatus returns NotSignatureValid only on Windows, 
+                        // so we have to do the extra cert signature check on all platforms
                         if (issuer == null && !isIssuer &&
                             id.Certificate != null && Utils.CompareDistinguishedName(id.Certificate.Subject, id.Certificate.Subject))
                         {
-                            // NotSignatureValid status is only returned on Windows, 
-                            // we have to verify the cert integrity on other platforms
                             if (!IsSignatureValid(id.Certificate))
                             {
                                 goto case X509ChainStatusFlags.NotSignatureValid;
@@ -831,7 +831,7 @@ namespace Opc.Ua
 
                         // ignore this error because the root check is done
                         // by looking the certificate up in the trusted issuer stores passed to the validator.
-                        // the ChainStatus uses the Windows trusted issuer stores.
+                        // the ChainStatus uses the trusted issuer stores.
                         break;
                     }
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -817,6 +817,17 @@ namespace Opc.Ua
 
                 case X509ChainStatusFlags.UntrustedRoot:
                     {
+                        // check if a self signed cert is valid
+                        if (id.Certificate != null && Utils.CompareDistinguishedName(id.Certificate.Subject, id.Certificate.Subject))
+                        {
+                            // NotSignatureValid status is only returned on Windows, 
+                            // we have to verify the cert integrity on other platforms
+                            if (!IsSignatureValid(id.Certificate))
+                            {
+                                goto case X509ChainStatusFlags.NotSignatureValid;
+                            }
+                        }
+
                         // ignore this error because the root check is done
                         // by looking the certificate up in the trusted issuer stores passed to the validator.
                         // the ChainStatus uses the Windows trusted issuer stores.
@@ -914,6 +925,22 @@ namespace Opc.Ua
                 oid.Value == "1.2.840.113549.1.1.5" || // sha1RSA
                 oid.Value == "1.3.14.3.2.13" ||        // sha1DSA
                 oid.Value == "1.3.14.3.2.27";          // dsaSHA1
+        }
+        /// <summary>
+        /// Returns if a self signed certificate is properly signed.
+        /// </summary>
+        private static bool IsSignatureValid(X509Certificate2 cert)
+        {
+            Org.BouncyCastle.X509.X509Certificate bcCert = new Org.BouncyCastle.X509.X509CertificateParser().ReadCertificate(cert.RawData);
+            try
+            {
+                bcCert.Verify(bcCert.GetPublicKey());
+            }
+            catch
+            {
+                return false;
+            }
+            return true;
         }
         #endregion
 

--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -818,7 +818,8 @@ namespace Opc.Ua
                 case X509ChainStatusFlags.UntrustedRoot:
                     {
                         // check if a self signed cert is valid
-                        if (id.Certificate != null && Utils.CompareDistinguishedName(id.Certificate.Subject, id.Certificate.Subject))
+                        if (issuer == null && !isIssuer &&
+                            id.Certificate != null && Utils.CompareDistinguishedName(id.Certificate.Subject, id.Certificate.Subject))
                         {
                             // NotSignatureValid status is only returned on Windows, 
                             // we have to verify the cert integrity on other platforms


### PR DESCRIPTION
NotSignatureValid is only returned on Windows, add the additional verification to be sure on all platforms.

Issue: #182 

The issue will not be fixed in .Net Core until V2.1 and then only for Linux, not MacOS.