### PR TITLE
Support .netstandard2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list' 
   - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
   - sudo apt-get update
-  - sudo apt-get install dotnet-dev-1.0.4 -y
+  - sudo apt-get install dotnet-dev-2.0.0 -y
 script: 
   - echo "========== build all .Net Core samples ============"
   - dotnet restore "UA-NetStandard.sln"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,18 @@ install:
   - sudo apt-get install dotnet-dev-2.0.0 -y
 script: 
   - echo "========== build all .Net Core samples ============"
+  - dotnet restore "UA Core Library.sln"
   - dotnet restore "UA-NetStandard.sln"
-  - dotnet build -c Debug -f netcoreapp1.1 SampleApplications/Samples/NetCoreConsoleClient
-  - dotnet build -c Debug -f netcoreapp1.1 SampleApplications/Samples/NetCoreConsoleServer
-  - dotnet build -c Release -f netcoreapp1.1 SampleApplications/Samples/NetCoreConsoleClient
-  - dotnet build -c Release -f netcoreapp1.1 SampleApplications/Samples/NetCoreConsoleServer
+  - dotnet build -c Debug SampleApplications/Samples/NetCoreConsoleClient
+  - dotnet build -c Debug SampleApplications/Samples/NetCoreConsoleServer
+  - dotnet build -c Release SampleApplications/Samples/NetCoreConsoleClient
+  - dotnet build -c Release SampleApplications/Samples/NetCoreConsoleServer
   - dotnet restore "SampleApplications/Workshop/Aggregation/UA Aggregation.sln"
-  - dotnet build -c Debug -f netcoreapp1.1 SampleApplications/Workshop/Aggregation/ConsoleAggregationServer
-  - dotnet build -c Release -f netcoreapp1.1 SampleApplications/Workshop/Aggregation/ConsoleAggregationServer
+  - dotnet build -c Debug SampleApplications/Workshop/Aggregation/ConsoleAggregationServer
+  - dotnet build -c Release SampleApplications/Workshop/Aggregation/ConsoleAggregationServer
   - dotnet restore "SampleApplications/Workshop/Reference/UA Reference.sln"
-  - dotnet build -c Debug -f netcoreapp1.1 SampleApplications/Workshop/Reference/ConsoleReferenceServer
-  - dotnet build -c Release -f netcoreapp1.1 SampleApplications/Workshop/Reference/ConsoleReferenceServer
+  - dotnet build -c Debug SampleApplications/Workshop/Reference/ConsoleReferenceServer
+  - dotnet build -c Release SampleApplications/Workshop/Reference/ConsoleReferenceServer
 
 after_script:
   - echo "========== build done ============"

--- a/SampleApplications/SDK/Opc.Ua.Client/Opc.Ua.Client.csproj
+++ b/SampleApplications/SDK/Opc.Ua.Client/Opc.Ua.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard1.4;net46</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
     <AssemblyName>Opc.Ua.Client</AssemblyName>
     <PackageId>Opc.Ua.Client</PackageId>
   </PropertyGroup>

--- a/SampleApplications/SDK/Opc.Ua.Client/Opc.Ua.Client.csproj
+++ b/SampleApplications/SDK/Opc.Ua.Client/Opc.Ua.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard1.3;netstandard1.4;net46</TargetFrameworks>
     <AssemblyName>Opc.Ua.Client</AssemblyName>
     <PackageId>Opc.Ua.Client</PackageId>
   </PropertyGroup>
@@ -9,5 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\Stack\Opc.Ua.Core\Opc.Ua.Core.csproj" />
   </ItemGroup>
+
+  <Target Name="GetPackagingOutputs" />
 
 </Project>

--- a/SampleApplications/SDK/Opc.Ua.Client/Opc.Ua.Client.csproj
+++ b/SampleApplications/SDK/Opc.Ua.Client/Opc.Ua.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.4;netstandard2.0</TargetFrameworks>
     <AssemblyName>Opc.Ua.Client</AssemblyName>
     <PackageId>Opc.Ua.Client</PackageId>
   </PropertyGroup>

--- a/SampleApplications/SDK/Opc.Ua.Configuration/Opc.Ua.Configuration.csproj
+++ b/SampleApplications/SDK/Opc.Ua.Configuration/Opc.Ua.Configuration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.4;netstandard2.0</TargetFrameworks>
     <AssemblyName>Opc.Ua.Configuration</AssemblyName>
     <PackageId>Opc.Ua.Configuration</PackageId>
   </PropertyGroup>

--- a/SampleApplications/SDK/Opc.Ua.Configuration/Opc.Ua.Configuration.csproj
+++ b/SampleApplications/SDK/Opc.Ua.Configuration/Opc.Ua.Configuration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard1.3;netstandard1.4;net46</TargetFrameworks>
     <AssemblyName>Opc.Ua.Configuration</AssemblyName>
     <PackageId>Opc.Ua.Configuration</PackageId>
   </PropertyGroup>
@@ -9,5 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\Stack\Opc.Ua.Core\Opc.Ua.Core.csproj" />
   </ItemGroup>
+  
+  <Target Name="GetPackagingOutputs" />
 
 </Project>

--- a/SampleApplications/SDK/Opc.Ua.Configuration/Opc.Ua.Configuration.csproj
+++ b/SampleApplications/SDK/Opc.Ua.Configuration/Opc.Ua.Configuration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard1.4;net46</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
     <AssemblyName>Opc.Ua.Configuration</AssemblyName>
     <PackageId>Opc.Ua.Configuration</PackageId>
   </PropertyGroup>

--- a/SampleApplications/SDK/Opc.Ua.Server/Opc.Ua.Server.csproj
+++ b/SampleApplications/SDK/Opc.Ua.Server/Opc.Ua.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard1.4;net46</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
     <AssemblyName>Opc.Ua.Server</AssemblyName>
     <PackageId>Opc.Ua.Server</PackageId>
   </PropertyGroup>

--- a/SampleApplications/SDK/Opc.Ua.Server/Opc.Ua.Server.csproj
+++ b/SampleApplications/SDK/Opc.Ua.Server/Opc.Ua.Server.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.4;netstandard2.0</TargetFrameworks>
+    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NO_HTTPS</DefineConstants>
     <AssemblyName>Opc.Ua.Server</AssemblyName>
     <PackageId>Opc.Ua.Server</PackageId>
   </PropertyGroup>

--- a/SampleApplications/SDK/Opc.Ua.Server/Opc.Ua.Server.csproj
+++ b/SampleApplications/SDK/Opc.Ua.Server/Opc.Ua.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard1.3;netstandard1.4;net46</TargetFrameworks>
     <AssemblyName>Opc.Ua.Server</AssemblyName>
     <PackageId>Opc.Ua.Server</PackageId>
   </PropertyGroup>
@@ -10,4 +10,6 @@
     <ProjectReference Include="..\..\..\Stack\Opc.Ua.Core\Opc.Ua.Core.csproj" />
   </ItemGroup>
 
+  <Target Name="GetPackagingOutputs" />
+  
 </Project>

--- a/SampleApplications/SDK/Opc.Ua.Server/Opc.Ua.Server.csproj
+++ b/SampleApplications/SDK/Opc.Ua.Server/Opc.Ua.Server.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard1.4;netstandard2.0</TargetFrameworks>
-    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NO_HTTPS</DefineConstants>
     <AssemblyName>Opc.Ua.Server</AssemblyName>
     <PackageId>Opc.Ua.Server</PackageId>
   </PropertyGroup>

--- a/SampleApplications/Samples/Client/Opc.Ua.SampleClient.csproj
+++ b/SampleApplications/Samples/Client/Opc.Ua.SampleClient.csproj
@@ -172,7 +172,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.3.3</Version>
+      <Version>5.4.0</Version>
     </PackageReference>
     <PackageReference Include="System.Xml.XmlDocument">
       <Version>4.3.0</Version>

--- a/SampleApplications/Samples/NetCoreConsoleClient/NetCoreConsoleClient.csproj
+++ b/SampleApplications/Samples/NetCoreConsoleClient/NetCoreConsoleClient.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>NetCoreConsoleClient</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>NetCoreConsoleClient</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SampleApplications/Samples/NetCoreConsoleClient/Program.cs
+++ b/SampleApplications/Samples/NetCoreConsoleClient/Program.cs
@@ -137,9 +137,8 @@ namespace NetCoreConsoleClient
 
             Console.WriteLine("3 - Create a session with OPC UA server.");
             var endpointConfiguration = EndpointConfiguration.Create(config);
-            var endpoint = new ConfiguredEndpoint(selectedEndpoint.Server, endpointConfiguration);
-            endpoint.Update(selectedEndpoint);
-            var session = await Session.Create(config, endpoint, true, ".Net Core OPC UA Console Client", 60000, new UserIdentity(new AnonymousIdentityToken()), null);
+            var endpoint = new ConfiguredEndpoint(null, selectedEndpoint, endpointConfiguration);
+            var session = await Session.Create(config, endpoint, false, ".Net Core OPC UA Console Client", 60000, new UserIdentity(new AnonymousIdentityToken()), null);
 
             Console.WriteLine("4 - Browse the OPC UA server namespace.");
             ReferenceDescriptionCollection references;

--- a/SampleApplications/Samples/NetCoreConsoleServer/NetCoreConsoleServer.csproj
+++ b/SampleApplications/Samples/NetCoreConsoleServer/NetCoreConsoleServer.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>NetCoreConsoleServer</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>NetCoreConsoleServer</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SampleApplications/Samples/Opc.Ua.Sample/Opc.Ua.Sample.csproj
+++ b/SampleApplications/Samples/Opc.Ua.Sample/Opc.Ua.Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>net46;netstandard1.4;netstandard2.0</TargetFrameworks>
     <AssemblyName>Opc.Ua.Sample</AssemblyName>
     <PackageId>Opc.Ua.Sample</PackageId>
   </PropertyGroup>

--- a/SampleApplications/Workshop/Aggregation/Client/MainForm.Designer.cs
+++ b/SampleApplications/Workshop/Aggregation/Client/MainForm.Designer.cs
@@ -27,6 +27,7 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using Opc.Ua.Client.Controls;
 using Opc.Ua.Server.Controls;
 
 namespace AggregationClient

--- a/SampleApplications/Workshop/Aggregation/ConsoleAggregationServer/ConsoleAggregationServer.csproj
+++ b/SampleApplications/Workshop/Aggregation/ConsoleAggregationServer/ConsoleAggregationServer.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>ConsoleAggregationServer</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>ConsoleAggregationServer</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/SampleApplications/Workshop/Reference/ConsoleReferenceServer/ConsoleReferenceServer.csproj
+++ b/SampleApplications/Workshop/Reference/ConsoleReferenceServer/ConsoleReferenceServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>ConsoleReferenceServer</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>ConsoleReferenceServer</PackageId>

--- a/SampleApplications/Workshop/Reference/Server/Reference Server.csproj
+++ b/SampleApplications/Workshop/Reference/Server/Reference Server.csproj
@@ -151,6 +151,11 @@
       <Name>Opc.Ua.Server</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Security.Cryptography.X509Certificates">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
+++ b/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard1.4;net46</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NET_STANDARD</DefineConstants>
     <AssemblyName>Opc.Ua.Core</AssemblyName>
     <PackageId>Opc.Ua.Core</PackageId>
@@ -19,6 +19,11 @@
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="1.1.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IdentityModel.Selectors" />
   </ItemGroup>
 
   <Target Name="GetPackagingOutputs" />

--- a/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
+++ b/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard1.3;netstandard1.4;net46</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NET_STANDARD</DefineConstants>
     <AssemblyName>Opc.Ua.Core</AssemblyName>
     <PackageId>Opc.Ua.Core</PackageId>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.2" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Private.ServiceModel" Version="4.3.0" />
@@ -20,5 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="1.1.2" />
   </ItemGroup>
+
+  <Target Name="GetPackagingOutputs" />
 
 </Project>

--- a/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
+++ b/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard1.4;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NET_STANDARD</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NO_HTTPS</DefineConstants>
     <AssemblyName>Opc.Ua.Core</AssemblyName>
     <PackageId>Opc.Ua.Core</PackageId>
   </PropertyGroup>

--- a/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
+++ b/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.4;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NET_STANDARD</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NO_HTTPS</DefineConstants>
     <AssemblyName>Opc.Ua.Core</AssemblyName>
     <PackageId>Opc.Ua.Core</PackageId>
   </PropertyGroup>
@@ -13,12 +14,22 @@
 
   <ItemGroup>
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <PackageReference Include="System.Private.ServiceModel" Version="4.3.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="1.1.2" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Private.ServiceModel" Version="4.4.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net451'">

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
@@ -671,8 +671,10 @@ namespace Opc.Ua.Bindings
                     {
                         throw ServiceResultException.Create(StatusCodes.BadTcpInternalError, args.SocketError.ToString());
                     }
-
-                    args.Dispose();
+                    else
+                    {
+                        m_ReadComplete(null, args);
+                    }
                 }
             }
             catch (ServiceResultException sre)

--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
@@ -667,7 +667,7 @@ namespace Opc.Ua.Bindings
                 if (!socket.ReceiveAsync(args))
                 {
                     // I/O completed synchronously
-                    if ((args.SocketError != SocketError.Success) || (args.BytesTransferred < (m_bytesToReceive - m_bytesReceived)))
+                    if (args.SocketError != SocketError.Success)
                     {
                         throw ServiceResultException.Create(StatusCodes.BadTcpInternalError, args.SocketError.ToString());
                     }

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
@@ -405,10 +405,14 @@ namespace Opc.Ua.Bindings
                     if (args.IsSocketError || (args.BytesTransferred < buffer.Count))
                     {
                         error = ServiceResult.Create(StatusCodes.BadConnectionClosed, args.SocketErrorString);
+                        HandleWriteComplete(null, state, args.BytesTransferred, error);
+                        args.Dispose();
                     }
-
-                    HandleWriteComplete(null, state, args.BytesTransferred, error);
-                    args.Dispose();
+                    else 
+                    {
+                        // success, call Complete
+                        OnWriteComplete(null, args);
+                    }
                 }
             }
             catch (Exception ex)
@@ -439,10 +443,13 @@ namespace Opc.Ua.Bindings
                     if (args.IsSocketError || (args.BytesTransferred < buffers.TotalSize))
                     {
                         error = ServiceResult.Create(StatusCodes.BadConnectionClosed, args.SocketErrorString);
+                        HandleWriteComplete(buffers, state, args.BytesTransferred, error);
+                        args.Dispose();
                     }
-
-                    HandleWriteComplete(buffers, state, args.BytesTransferred, error);
-                    args.Dispose();
+                    else
+                    {
+                        OnWriteComplete(null, args);
+                    }
                 }
             }
             catch (Exception ex)

--- a/UA Core Library.sln
+++ b/UA Core Library.sln
@@ -1,0 +1,40 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.16
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Opc.Ua.Core", "Stack\Opc.Ua.Core\Opc.Ua.Core.csproj", "{84FE2F0A-4192-4D2C-8097-9C396C2375E8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Opc.Ua.Server", "SampleApplications\SDK\Opc.Ua.Server\Opc.Ua.Server.csproj", "{259094EF-B5FC-412D-8187-0ED7FF763D55}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Opc.Ua.Configuration", "SampleApplications\SDK\Opc.Ua.Configuration\Opc.Ua.Configuration.csproj", "{63BEB4B6-E96D-478E-B41D-B42CED6F8E7B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Opc.Ua.Client", "SampleApplications\SDK\Opc.Ua.Client\Opc.Ua.Client.csproj", "{DCA9C101-199F-4519-9F97-4CD22817EBE8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{84FE2F0A-4192-4D2C-8097-9C396C2375E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84FE2F0A-4192-4D2C-8097-9C396C2375E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84FE2F0A-4192-4D2C-8097-9C396C2375E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84FE2F0A-4192-4D2C-8097-9C396C2375E8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{259094EF-B5FC-412D-8187-0ED7FF763D55}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{259094EF-B5FC-412D-8187-0ED7FF763D55}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{259094EF-B5FC-412D-8187-0ED7FF763D55}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{259094EF-B5FC-412D-8187-0ED7FF763D55}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63BEB4B6-E96D-478E-B41D-B42CED6F8E7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63BEB4B6-E96D-478E-B41D-B42CED6F8E7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63BEB4B6-E96D-478E-B41D-B42CED6F8E7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63BEB4B6-E96D-478E-B41D-B42CED6F8E7B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DCA9C101-199F-4519-9F97-4CD22817EBE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DCA9C101-199F-4519-9F97-4CD22817EBE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DCA9C101-199F-4519-9F97-4CD22817EBE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DCA9C101-199F-4519-9F97-4CD22817EBE8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/nuget/Opc.Ua.Symbols.nuspec
+++ b/nuget/Opc.Ua.Symbols.nuspec
@@ -12,19 +12,44 @@
     <licenseUrl>http://opcfoundation.github.io/UA-.NETStandardLibrary</licenseUrl>
     <tags>OPCFoundation OPC-UA netstandard ios linux dotnet net netcore uwp</tags>
     <dependencies>
-      <group targetFramework="netstandard1.4" >
+      <group targetFramework="net46" >
         <dependency id="Microsoft.AspNetCore.Server.Kestrel" version="1.1.2"/>
         <dependency id="Microsoft.AspNetCore.Server.Kestrel.Https" version= "1.1.2"/>
-        <dependency id="NETStandard.Library" version="1.6.1"/>
-        <dependency id="Newtonsoft.Json" version="10.0.2"/>
-        <dependency id="Portable.BouncyCastle" version="1.8.1.2"/>
+        <dependency id="Newtonsoft.Json" version="10.0.3"/>
+        <dependency id="Portable.BouncyCastle" version="1.8.1.3"/>
         <dependency id="System.Data.Common" version="4.3.0"/>
         <dependency id="System.Private.ServiceModel" version="4.3.0"/>
         <dependency id="System.ServiceModel.Primitives" version="4.3.0"/>
       </group>
+      <group targetFramework="netstandard1.4" >
+        <dependency id="Microsoft.AspNetCore.Server.Kestrel" version="1.1.2"/>
+        <dependency id="Microsoft.AspNetCore.Server.Kestrel.Https" version= "1.1.2"/>
+        <dependency id="Newtonsoft.Json" version="10.0.3"/>
+        <dependency id="Portable.BouncyCastle" version="1.8.1.3"/>
+        <dependency id="System.Data.Common" version="4.3.0"/>
+        <dependency id="System.Private.ServiceModel" version="4.3.0"/>
+        <dependency id="System.ServiceModel.Primitives" version="4.3.0"/>
+      </group>
+      <group targetFramework="netstandard2.0" >
+        <dependency id="Microsoft.AspNetCore.Server.Kestrel" version="2.0.0"/>
+        <dependency id="Microsoft.AspNetCore.Server.Kestrel.Https" version= "2.0.0"/>
+        <dependency id="Newtonsoft.Json" version="10.0.3"/>
+        <dependency id="Portable.BouncyCastle" version="1.8.1.3"/>
+        <dependency id="System.Data.Common" version="4.3.0"/>
+        <dependency id="System.Private.ServiceModel" version="4.4.0"/>
+        <dependency id="System.ServiceModel.Primitives" version="4.4.0"/>
+      </group>
     </dependencies>
   </metadata>
   <files>
+    <file src="..\Stack\Opc.Ua.Core\bin\Debug\net46\Opc.Ua.Core.dll" target="lib\net46" />
+    <file src="..\Stack\Opc.Ua.Core\bin\Debug\net46\Opc.Ua.Core.pdb" target="lib\net46" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Client\bin\Debug\net46\Opc.Ua.Client.dll" target="lib\net46" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Client\bin\Debug\net46\Opc.Ua.Client.pdb" target="lib\net46" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Server\bin\Debug\net46\Opc.Ua.Server.dll" target="lib\net46" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Server\bin\Debug\net46\Opc.Ua.Server.pdb" target="lib\net46" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Configuration\bin\Debug\net46\Opc.Ua.Configuration.dll" target="lib\net46" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Configuration\bin\Debug\net46\Opc.Ua.Configuration.pdb" target="lib\net46" />
     <file src="..\Stack\Opc.Ua.Core\bin\Debug\netstandard1.4\Opc.Ua.Core.dll" target="lib\netstandard1.4" />
     <file src="..\Stack\Opc.Ua.Core\bin\Debug\netstandard1.4\Opc.Ua.Core.pdb" target="lib\netstandard1.4" />
     <file src="..\SampleApplications\SDK\Opc.Ua.Client\bin\Debug\netstandard1.4\Opc.Ua.Client.dll" target="lib\netstandard1.4" />
@@ -33,5 +58,13 @@
     <file src="..\SampleApplications\SDK\Opc.Ua.Server\bin\Debug\netstandard1.4\Opc.Ua.Server.pdb" target="lib\netstandard1.4" />
     <file src="..\SampleApplications\SDK\Opc.Ua.Configuration\bin\Debug\netstandard1.4\Opc.Ua.Configuration.dll" target="lib\netstandard1.4" />
     <file src="..\SampleApplications\SDK\Opc.Ua.Configuration\bin\Debug\netstandard1.4\Opc.Ua.Configuration.pdb" target="lib\netstandard1.4" />
+    <file src="..\Stack\Opc.Ua.Core\bin\Debug\netstandard2.0\Opc.Ua.Core.dll" target="lib\netstandard2.0" />
+    <file src="..\Stack\Opc.Ua.Core\bin\Debug\netstandard2.0\Opc.Ua.Core.pdb" target="lib\netstandard2.0" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Client\bin\Debug\netstandard2.0\Opc.Ua.Client.dll" target="lib\netstandard2.0" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Client\bin\Debug\netstandard2.0\Opc.Ua.Client.pdb" target="lib\netstandard2.0" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Server\bin\Debug\netstandard2.0\Opc.Ua.Server.dll" target="lib\netstandard2.0" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Server\bin\Debug\netstandard2.0\Opc.Ua.Server.pdb" target="lib\netstandard2.0" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Configuration\bin\Debug\netstandard2.0\Opc.Ua.Configuration.dll" target="lib\netstandard2.0" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Configuration\bin\Debug\netstandard2.0\Opc.Ua.Configuration.pdb" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/nuget/Opc.Ua.nuspec
+++ b/nuget/Opc.Ua.nuspec
@@ -12,22 +12,47 @@
     <licenseUrl>http://opcfoundation.github.io/UA-.NETStandardLibrary</licenseUrl>
     <tags>OPCFoundation OPC-UA netstandard ios linux dotnet net netcore uwp</tags>
     <dependencies>
-      <group targetFramework="netstandard1.4" >
+      <group targetFramework="net46" >
         <dependency id="Microsoft.AspNetCore.Server.Kestrel" version="1.1.2"/>
         <dependency id="Microsoft.AspNetCore.Server.Kestrel.Https" version= "1.1.2"/>
-        <dependency id="NETStandard.Library" version="1.6.1"/>
-        <dependency id="Newtonsoft.Json" version="10.0.2"/>
+        <dependency id="Newtonsoft.Json" version="10.0.3"/>
         <dependency id="Portable.BouncyCastle" version="1.8.1.3"/>
         <dependency id="System.Data.Common" version="4.3.0"/>
         <dependency id="System.Private.ServiceModel" version="4.3.0"/>
         <dependency id="System.ServiceModel.Primitives" version="4.3.0"/>
       </group>
+      <group targetFramework="netstandard1.4" >
+        <dependency id="Microsoft.AspNetCore.Server.Kestrel" version="1.1.2"/>
+        <dependency id="Microsoft.AspNetCore.Server.Kestrel.Https" version= "1.1.2"/>
+        <dependency id="Newtonsoft.Json" version="10.0.3"/>
+        <dependency id="Portable.BouncyCastle" version="1.8.1.3"/>
+        <dependency id="System.Data.Common" version="4.3.0"/>
+        <dependency id="System.Private.ServiceModel" version="4.3.0"/>
+        <dependency id="System.ServiceModel.Primitives" version="4.3.0"/>
+      </group>
+      <group targetFramework="netstandard2.0" >
+        <dependency id="Microsoft.AspNetCore.Server.Kestrel" version="2.0.0"/>
+        <dependency id="Microsoft.AspNetCore.Server.Kestrel.Https" version= "2.0.0"/>
+        <dependency id="Newtonsoft.Json" version="10.0.3"/>
+        <dependency id="Portable.BouncyCastle" version="1.8.1.3"/>
+        <dependency id="System.Data.Common" version="4.3.0"/>
+        <dependency id="System.Private.ServiceModel" version="4.4.0"/>
+        <dependency id="System.ServiceModel.Primitives" version="4.4.0"/>
+      </group>
     </dependencies>
   </metadata>
   <files>
+    <file src="..\Stack\Opc.Ua.Core\bin\Release\net46\Opc.Ua.Core.dll" target="lib\net46" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Client\bin\Release\net46\Opc.Ua.Client.dll" target="lib\net46" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Server\bin\Release\net46\Opc.Ua.Server.dll" target="lib\net46" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Configuration\bin\Release\net46\Opc.Ua.Configuration.dll" target="lib\net46" />
     <file src="..\Stack\Opc.Ua.Core\bin\Release\netstandard1.4\Opc.Ua.Core.dll" target="lib\netstandard1.4" />
     <file src="..\SampleApplications\SDK\Opc.Ua.Client\bin\Release\netstandard1.4\Opc.Ua.Client.dll" target="lib\netstandard1.4" />
     <file src="..\SampleApplications\SDK\Opc.Ua.Server\bin\Release\netstandard1.4\Opc.Ua.Server.dll" target="lib\netstandard1.4" />
     <file src="..\SampleApplications\SDK\Opc.Ua.Configuration\bin\Release\netstandard1.4\Opc.Ua.Configuration.dll" target="lib\netstandard1.4" />
+    <file src="..\Stack\Opc.Ua.Core\bin\Release\netstandard2.0\Opc.Ua.Core.dll" target="lib\netstandard2.0" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Client\bin\Release\netstandard2.0\Opc.Ua.Client.dll" target="lib\netstandard2.0" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Server\bin\Release\netstandard2.0\Opc.Ua.Server.dll" target="lib\netstandard2.0" />
+    <file src="..\SampleApplications\SDK\Opc.Ua.Configuration\bin\Release\netstandard2.0\Opc.Ua.Configuration.dll" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/nuget/Opc.Ua.nuspec
+++ b/nuget/Opc.Ua.nuspec
@@ -17,7 +17,7 @@
         <dependency id="Microsoft.AspNetCore.Server.Kestrel.Https" version= "1.1.2"/>
         <dependency id="NETStandard.Library" version="1.6.1"/>
         <dependency id="Newtonsoft.Json" version="10.0.2"/>
-        <dependency id="Portable.BouncyCastle" version="1.8.1.2"/>
+        <dependency id="Portable.BouncyCastle" version="1.8.1.3"/>
         <dependency id="System.Data.Common" version="4.3.0"/>
         <dependency id="System.Private.ServiceModel" version="4.3.0"/>
         <dependency id="System.ServiceModel.Primitives" version="4.3.0"/>


### PR DESCRIPTION
-Fix a bug in the TCP channel when .NetStandard2.0 uses synchronous return from SendAsync/ReceiveAsync, these cases were not properly handled and never called complete.
-build related fixes to support net46/uap/netstandard1.4 in one tbd nuget packet
-fix appveyor/travis builds