### PR TITLE
Utils.Clone() bug

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -1731,7 +1731,15 @@ namespace Opc.Ua
                 {
                     return castedObject.MemberwiseClone();
                 }
-            }
+            }           
+            // copy Opc.Ua.TimeZoneDataType
+            {
+                TimeZoneDataType castedObject = value as TimeZoneDataType;
+                if (castedObject != null)
+                {
+                    return castedObject.MemberwiseClone();
+                }
+            }           
 
             // don't know how to clone object.
             throw new NotSupportedException(Utils.Format("Don't know how to clone objects of type '{0}'", type.FullName));


### PR DESCRIPTION
Steps to reproduce:
Create a variable instance of DataType = Opc.Ua.TimeZoneDataType
Read the variable

Actual result:
Opc.Ua.Utils.Clone() throws exception because the cast to Opc.Ua.TimeZoneDataType is not supported.

Expected result:
Variable instance of DataType = Opc.Ua.TimeZoneDataType can be read.