### PR TITLE
Trust only issuer certificates in the trusted store.

### DIFF
--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -475,11 +475,13 @@ namespace Opc.Ua
                         issuer = await GetIssuer(certificate, collection, null, true);
                     }
                 }
+                else
+                {
+                    isTrusted = true;
+                }
 
                 if (issuer != null)
                 {
-                    isTrusted = true;
-
                     issuers.Add(issuer);
                     certificate = await issuer.Find(false);
 
@@ -488,10 +490,6 @@ namespace Opc.Ua
                     {
                         break;
                     }
-                }
-                else
-                {
-                    isTrusted = false;
                 }
             }
             while (issuer != null);


### PR DESCRIPTION
Fix #257 
Trust only issuer certificates in the trusted store.
Certs in issuer store are only used to verify the cert chain.

Tested against latest CTT. Make sure CA cert/crl are in the trusted store (UA Applications)