### PR TITLE
X509store mac fix and travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   - osx
 sudo: required
 dist: trusty
-osx_image: xcode9.1
+osx_image: xcode8.1
 
 # workaround: see travis-ci/travis-ci#8552
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,7 @@ osx_image: xcode9.1
 
 # workaround: see travis-ci/travis-ci#8552
 before_install:
-  case $TRAVIS_OS_NAME in
-    osx)
-      brew update 
-      ;;
-  esac
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi; 
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   - osx
 sudo: required
 dist: trusty
-osx_image: xcode8.1
+osx_image: xcode8.3
 
 # workaround: see travis-ci/travis-ci#8552
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,12 @@ os:
   - osx
 sudo: required
 dist: trusty
-osx_image: xcode8.3
+osx_image: xcode9.1
 
 # workaround: see travis-ci/travis-ci#8552
-before_install:
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi; 
+matrix:
+  allow_failures:
+    - os: osx
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ dist: trusty
 osx_image: xcode9.1
 
 # workaround: see travis-ci/travis-ci#8552
-install:
+before_install:
   case $TRAVIS_OS_NAME in
     osx)
       brew update 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: csharp
+mono: none
+dotnet: 2.0.0
+os:
+  - linux
+  - osx
 sudo: required
 dist: trusty
+osx_image: xcode9.1
 addons:
   apt:
     sources:
     packages:
-install:
-  - sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list' 
-  - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
-  - sudo apt-get update
-  - sudo apt-get install dotnet-dev-2.0.0 -y
 script: 
   - echo "========== build all .Net Core samples ============"
   - dotnet restore "UA Core Library.sln"
@@ -24,6 +25,11 @@ script:
   - dotnet restore "SampleApplications/Workshop/Reference/UA Reference.sln"
   - dotnet build -c Debug SampleApplications/Workshop/Reference/ConsoleReferenceServer
   - dotnet build -c Release SampleApplications/Workshop/Reference/ConsoleReferenceServer
+  - echo "========== run .Net Core samples ============"
+  - cd SampleApplications/Samples/NetCoreConsoleServer/bin/Debug/netcoreapp2.0
+  - dotnet NetCoreConsoleServer.dll -t 10 -a
+  - cd $TRAVIS_BUILD_DIR
+  - ./testclientserver.sh
 
 after_script:
   - echo "========== build done ============"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,15 @@ os:
 sudo: required
 dist: trusty
 osx_image: xcode9.1
+
+# workaround: see travis-ci/travis-ci#8552
+install:
+  case $TRAVIS_OS_NAME in
+    osx)
+      brew update 
+      ;;
+  esac
+
 addons:
   apt:
     sources:

--- a/SampleApplications/Samples/NetCoreConsoleClient/NetCoreConsoleClient.csproj
+++ b/SampleApplications/Samples/NetCoreConsoleClient/NetCoreConsoleClient.csproj
@@ -16,4 +16,8 @@
     <Folder Include="Properties\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/SampleApplications/Samples/NetCoreConsoleClient/Program.cs
+++ b/SampleApplications/Samples/NetCoreConsoleClient/Program.cs
@@ -12,32 +12,90 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
+using Mono.Options;
 using Opc.Ua;
 using Opc.Ua.Client;
-using System.Security.Cryptography.X509Certificates;
 
 namespace NetCoreConsoleClient
 {
     public class Program
     {
+
+        private const int ERROR_OK = 0;
+        private const int ERROR_CREATE_APPLICATION = 0x11;
+        private const int ERROR_DISCOVER_ENDPOINTS = 0x12;
+        private const int ERROR_CREATE_SESSION = 0x13;
+        private const int ERROR_BROWSE_NAMESPACE = 0x14;
+        private const int ERROR_CREATE_SUBSCRIPTION = 0x15;
+        private const int ERROR_MONITORED_ITEM = 0x16;
+        private const int ERROR_ADD_SUBSCRIPTION = 0x17;
+        private const int ERROR_RUNNING = 0x18;
+        private const int ERROR_NO_KEEPALIVE = 0x30;
+        private const int ERROR_INVALID_COMMAND_LINE = 0x100;
+
         public static void Main(string[] args)
         {
             Console.WriteLine(".Net Core OPC UA Console Client sample");
+
+            // command line options
+            bool showHelp = false;
+            int stopTimeout = Timeout.Infinite;
+            bool autoAccept = true;
+
+            Mono.Options.OptionSet options = new Mono.Options.OptionSet {
+                { "h|help", "show this message and exit", h => showHelp = h != null },
+                { "a|autoaccept", "auto accept certificates (for testing only)", a => autoAccept = a != null },
+                { "t|timeout=", "the number of seconds until the server stops.", (int t) => stopTimeout = t * 1000 }
+            };
+
+            IList<string> extraArgs = null;
+            try
+            {
+                extraArgs = options.Parse(args);
+                if (extraArgs.Count > 1)
+                {
+                    foreach (string extraArg in extraArgs)
+                    {
+                        Console.WriteLine("Error: Unknown option: {0}", extraArg);
+                        showHelp = true;
+                    }
+                }
+            }
+            catch (OptionException e)
+            {
+                Console.WriteLine(e.Message);
+                showHelp = true;
+            }
+
+            if (showHelp)
+            {
+                // show some app description message
+                Console.WriteLine("Usage: dotnet NetCoreConsoleClient.dll [OPTIONS] [ENDPOINTURL]");
+                Console.WriteLine();
+
+                // output the options
+                Console.WriteLine("Options:");
+                options.WriteOptionDescriptions(Console.Out);
+                Environment.ExitCode = ERROR_INVALID_COMMAND_LINE;
+                return;
+            }
+
             string endpointURL;
-            if (args.Length == 0)
+            if (extraArgs.Count == 0)
             {
                 // use OPC UA .Net Sample server 
-                endpointURL = "opc.tcp://" + Utils.GetHostName() + ":51210/UA/SampleServer";
+                endpointURL = "opc.tcp://localhost:51210/UA/SampleServer";
             }
             else
             {
-                endpointURL = args[0];
+                endpointURL = extraArgs[0];
             }
             try
             {
-                Task t = ConsoleSampleClient(endpointURL);
-                t.Wait();
+                ConsoleSampleClient(endpointURL, stopTimeout, autoAccept).Wait();
             }
             catch (Exception e)
             {
@@ -45,21 +103,23 @@ namespace NetCoreConsoleClient
             }
         }
 
-        public static async Task ConsoleSampleClient(string endpointURL)
+        public static async Task ConsoleSampleClient(string endpointURL, int timeOut, bool autoAccept)
         {
             Console.WriteLine("1 - Create an Application Configuration.");
+            Environment.ExitCode = ERROR_CREATE_APPLICATION;
+
             Utils.SetTraceOutput(Utils.TraceOutput.DebugAndFile);
             var config = new ApplicationConfiguration()
             {
                 ApplicationName = "UA Core Sample Client",
                 ApplicationType = ApplicationType.Client,
-                ApplicationUri = "urn:"+Utils.GetHostName()+":OPCFoundation:CoreSampleClient",
+                ApplicationUri = "urn:" + Utils.GetHostName() + ":OPCFoundation:CoreSampleClient",
                 SecurityConfiguration = new SecurityConfiguration
                 {
                     ApplicationCertificate = new CertificateIdentifier
                     {
                         StoreType = "X509Store",
-                        StorePath = "CurrentUser\\UA_MachineDefault",
+                        StorePath = "CurrentUser\\My",
                         SubjectName = "UA Core Sample Client"
                     },
                     TrustedPeerCertificates = new CertificateTrustList
@@ -78,7 +138,7 @@ namespace NetCoreConsoleClient
                         StorePath = "OPC Foundation/CertificateStores/RejectedCertificates",
                     },
                     NonceLength = 32,
-                    AutoAcceptUntrustedCertificates = true
+                    AutoAcceptUntrustedCertificates = autoAccept
                 },
                 TransportConfigurations = new TransportConfigurationCollection(),
                 TransportQuotas = new TransportQuotas { OperationTimeout = 15000 },
@@ -131,16 +191,19 @@ namespace NetCoreConsoleClient
             }
 
             Console.WriteLine("2 - Discover endpoints of {0}.", endpointURL);
-            var selectedEndpoint = CoreClientUtils.SelectEndpoint(endpointURL, haveAppCertificate);
-            Console.WriteLine("    Selected endpoint uses: {0}", 
+            Environment.ExitCode = ERROR_DISCOVER_ENDPOINTS;
+            var selectedEndpoint = CoreClientUtils.SelectEndpoint(endpointURL, haveAppCertificate, 15000);
+            Console.WriteLine("    Selected endpoint uses: {0}",
                 selectedEndpoint.SecurityPolicyUri.Substring(selectedEndpoint.SecurityPolicyUri.LastIndexOf('#') + 1));
 
             Console.WriteLine("3 - Create a session with OPC UA server.");
+            Environment.ExitCode = ERROR_CREATE_SESSION;
             var endpointConfiguration = EndpointConfiguration.Create(config);
             var endpoint = new ConfiguredEndpoint(null, selectedEndpoint, endpointConfiguration);
             var session = await Session.Create(config, endpoint, false, ".Net Core OPC UA Console Client", 60000, new UserIdentity(new AnonymousIdentityToken()), null);
 
             Console.WriteLine("4 - Browse the OPC UA server namespace.");
+            Environment.ExitCode = ERROR_BROWSE_NAMESPACE;
             ReferenceDescriptionCollection references;
             Byte[] continuationPoint;
 
@@ -183,24 +246,51 @@ namespace NetCoreConsoleClient
             }
 
             Console.WriteLine("5 - Create a subscription with publishing interval of 1 second.");
+            Environment.ExitCode = ERROR_CREATE_SUBSCRIPTION;
             var subscription = new Subscription(session.DefaultSubscription) { PublishingInterval = 1000 };
 
             Console.WriteLine("6 - Add a list of items (server current time and status) to the subscription.");
+            Environment.ExitCode = ERROR_MONITORED_ITEM;
             var list = new List<MonitoredItem> {
                 new MonitoredItem(subscription.DefaultItem)
                 {
-                    DisplayName = "ServerStatusCurrentTime", StartNodeId = "i=2258"
+                    DisplayName = "ServerStatusCurrentTime", StartNodeId = "i="+Variables.Server_ServerStatus_CurrentTime.ToString()
                 }
             };
             list.ForEach(i => i.Notification += OnNotification);
             subscription.AddItems(list);
 
             Console.WriteLine("7 - Add the subscription to the session.");
+            Environment.ExitCode = ERROR_ADD_SUBSCRIPTION;
             session.AddSubscription(subscription);
             subscription.Create();
 
-            Console.WriteLine("8 - Running...Press any key to exit...");
-            Console.ReadKey(true);
+            Console.WriteLine("8 - Running...Press Ctrl-C to exit...");
+            Environment.ExitCode = ERROR_RUNNING;
+
+            ManualResetEvent quitEvent = new ManualResetEvent(false);
+            try
+            {
+                Console.CancelKeyPress += (sender, eArgs) =>
+                {
+                    quitEvent.Set();
+                    eArgs.Cancel = true;
+                };
+            }
+            catch
+            {
+            }
+
+            // wait for timeout or Ctrl-C
+            quitEvent.WaitOne(timeOut);
+
+            // return error conditions
+            if (session.KeepAliveStopped)
+            {
+                Environment.ExitCode = ERROR_NO_KEEPALIVE;
+                return;
+            }
+            Environment.ExitCode = ERROR_OK;
         }
 
         private static void OnNotification(MonitoredItem item, MonitoredItemNotificationEventArgs e)

--- a/SampleApplications/Samples/NetCoreConsoleClient/Program.cs
+++ b/SampleApplications/Samples/NetCoreConsoleClient/Program.cs
@@ -38,8 +38,9 @@ namespace NetCoreConsoleClient
 
     public class Program
     {
+        static ExitCode exitCode;
 
-        public static void Main(string[] args)
+        public static int Main(string[] args)
         {
             Console.WriteLine(".Net Core OPC UA Console Client sample");
 
@@ -82,8 +83,7 @@ namespace NetCoreConsoleClient
                 // output the options
                 Console.WriteLine("Options:");
                 options.WriteOptionDescriptions(Console.Out);
-                Environment.ExitCode = (int)ExitCode.ErrorInvalidCommandLine;
-                return;
+                return (int)ExitCode.ErrorInvalidCommandLine;
             }
 
             string endpointURL;
@@ -104,12 +104,14 @@ namespace NetCoreConsoleClient
             {
                 Console.WriteLine("Exit due to Exception: {0}", e.Message);
             }
+
+            return (int)exitCode;
         }
 
         public static async Task ConsoleSampleClient(string endpointURL, int timeOut, bool autoAccept)
         {
             Console.WriteLine("1 - Create an Application Configuration.");
-            Environment.ExitCode = (int)ExitCode.ErrorCreateApplication;
+            exitCode = ExitCode.ErrorCreateApplication;
 
             Utils.SetTraceOutput(Utils.TraceOutput.DebugAndFile);
             var config = new ApplicationConfiguration()
@@ -194,19 +196,19 @@ namespace NetCoreConsoleClient
             }
 
             Console.WriteLine("2 - Discover endpoints of {0}.", endpointURL);
-            Environment.ExitCode = (int)ExitCode.ErrorDiscoverEndpoints;
+            exitCode = ExitCode.ErrorDiscoverEndpoints;
             var selectedEndpoint = CoreClientUtils.SelectEndpoint(endpointURL, haveAppCertificate, 15000);
             Console.WriteLine("    Selected endpoint uses: {0}",
                 selectedEndpoint.SecurityPolicyUri.Substring(selectedEndpoint.SecurityPolicyUri.LastIndexOf('#') + 1));
 
             Console.WriteLine("3 - Create a session with OPC UA server.");
-            Environment.ExitCode = (int)ExitCode.ErrorCreateSession;
+            exitCode = ExitCode.ErrorCreateSession;
             var endpointConfiguration = EndpointConfiguration.Create(config);
             var endpoint = new ConfiguredEndpoint(null, selectedEndpoint, endpointConfiguration);
             var session = await Session.Create(config, endpoint, false, ".Net Core OPC UA Console Client", 60000, new UserIdentity(new AnonymousIdentityToken()), null);
 
             Console.WriteLine("4 - Browse the OPC UA server namespace.");
-            Environment.ExitCode = (int)ExitCode.ErrorBrowseNamespace;
+            exitCode = ExitCode.ErrorBrowseNamespace;
             ReferenceDescriptionCollection references;
             Byte[] continuationPoint;
 
@@ -249,11 +251,11 @@ namespace NetCoreConsoleClient
             }
 
             Console.WriteLine("5 - Create a subscription with publishing interval of 1 second.");
-            Environment.ExitCode = (int)ExitCode.ErrorCreateSubscription;
+            exitCode = ExitCode.ErrorCreateSubscription;
             var subscription = new Subscription(session.DefaultSubscription) { PublishingInterval = 1000 };
 
             Console.WriteLine("6 - Add a list of items (server current time and status) to the subscription.");
-            Environment.ExitCode = (int)ExitCode.ErrorMonitoredItem;
+            exitCode = ExitCode.ErrorMonitoredItem;
             var list = new List<MonitoredItem> {
                 new MonitoredItem(subscription.DefaultItem)
                 {
@@ -264,12 +266,12 @@ namespace NetCoreConsoleClient
             subscription.AddItems(list);
 
             Console.WriteLine("7 - Add the subscription to the session.");
-            Environment.ExitCode = (int)ExitCode.ErrorAddSubscription;
+            exitCode = ExitCode.ErrorAddSubscription;
             session.AddSubscription(subscription);
             subscription.Create();
 
             Console.WriteLine("8 - Running...Press Ctrl-C to exit...");
-            Environment.ExitCode = (int)ExitCode.ErrorRunning;
+            exitCode = ExitCode.ErrorRunning;
 
             ManualResetEvent quitEvent = new ManualResetEvent(false);
             try
@@ -290,10 +292,10 @@ namespace NetCoreConsoleClient
             // return error conditions
             if (session.KeepAliveStopped)
             {
-                Environment.ExitCode = (int)ExitCode.ErrorNoKeepAlive;
+                exitCode = ExitCode.ErrorNoKeepAlive;
                 return;
             }
-            Environment.ExitCode = (int)ExitCode.Ok;
+            exitCode = ExitCode.Ok;
         }
 
         private static void OnNotification(MonitoredItem item, MonitoredItemNotificationEventArgs e)

--- a/SampleApplications/Samples/NetCoreConsoleClient/Program.cs
+++ b/SampleApplications/Samples/NetCoreConsoleClient/Program.cs
@@ -21,20 +21,23 @@ using Opc.Ua.Client;
 
 namespace NetCoreConsoleClient
 {
+    public enum ExitCode : int
+    {
+        Ok = 0,
+        ErrorCreateApplication = 0x11,
+        ErrorDiscoverEndpoints = 0x12,
+        ErrorCreateSession = 0x13,
+        ErrorBrowseNamespace = 0x14,
+        ErrorCreateSubscription = 0x15,
+        ErrorMonitoredItem = 0x16,
+        ErrorAddSubscription = 0x17,
+        ErrorRunning = 0x18,
+        ErrorNoKeepAlive = 0x30,
+        ErrorInvalidCommandLine = 0x100
+    };
+
     public class Program
     {
-
-        private const int ERROR_OK = 0;
-        private const int ERROR_CREATE_APPLICATION = 0x11;
-        private const int ERROR_DISCOVER_ENDPOINTS = 0x12;
-        private const int ERROR_CREATE_SESSION = 0x13;
-        private const int ERROR_BROWSE_NAMESPACE = 0x14;
-        private const int ERROR_CREATE_SUBSCRIPTION = 0x15;
-        private const int ERROR_MONITORED_ITEM = 0x16;
-        private const int ERROR_ADD_SUBSCRIPTION = 0x17;
-        private const int ERROR_RUNNING = 0x18;
-        private const int ERROR_NO_KEEPALIVE = 0x30;
-        private const int ERROR_INVALID_COMMAND_LINE = 0x100;
 
         public static void Main(string[] args)
         {
@@ -79,7 +82,7 @@ namespace NetCoreConsoleClient
                 // output the options
                 Console.WriteLine("Options:");
                 options.WriteOptionDescriptions(Console.Out);
-                Environment.ExitCode = ERROR_INVALID_COMMAND_LINE;
+                Environment.ExitCode = (int)ExitCode.ErrorInvalidCommandLine;
                 return;
             }
 
@@ -106,7 +109,7 @@ namespace NetCoreConsoleClient
         public static async Task ConsoleSampleClient(string endpointURL, int timeOut, bool autoAccept)
         {
             Console.WriteLine("1 - Create an Application Configuration.");
-            Environment.ExitCode = ERROR_CREATE_APPLICATION;
+            Environment.ExitCode = (int)ExitCode.ErrorCreateApplication;
 
             Utils.SetTraceOutput(Utils.TraceOutput.DebugAndFile);
             var config = new ApplicationConfiguration()
@@ -191,19 +194,19 @@ namespace NetCoreConsoleClient
             }
 
             Console.WriteLine("2 - Discover endpoints of {0}.", endpointURL);
-            Environment.ExitCode = ERROR_DISCOVER_ENDPOINTS;
+            Environment.ExitCode = (int)ExitCode.ErrorDiscoverEndpoints;
             var selectedEndpoint = CoreClientUtils.SelectEndpoint(endpointURL, haveAppCertificate, 15000);
             Console.WriteLine("    Selected endpoint uses: {0}",
                 selectedEndpoint.SecurityPolicyUri.Substring(selectedEndpoint.SecurityPolicyUri.LastIndexOf('#') + 1));
 
             Console.WriteLine("3 - Create a session with OPC UA server.");
-            Environment.ExitCode = ERROR_CREATE_SESSION;
+            Environment.ExitCode = (int)ExitCode.ErrorCreateSession;
             var endpointConfiguration = EndpointConfiguration.Create(config);
             var endpoint = new ConfiguredEndpoint(null, selectedEndpoint, endpointConfiguration);
             var session = await Session.Create(config, endpoint, false, ".Net Core OPC UA Console Client", 60000, new UserIdentity(new AnonymousIdentityToken()), null);
 
             Console.WriteLine("4 - Browse the OPC UA server namespace.");
-            Environment.ExitCode = ERROR_BROWSE_NAMESPACE;
+            Environment.ExitCode = (int)ExitCode.ErrorBrowseNamespace;
             ReferenceDescriptionCollection references;
             Byte[] continuationPoint;
 
@@ -246,11 +249,11 @@ namespace NetCoreConsoleClient
             }
 
             Console.WriteLine("5 - Create a subscription with publishing interval of 1 second.");
-            Environment.ExitCode = ERROR_CREATE_SUBSCRIPTION;
+            Environment.ExitCode = (int)ExitCode.ErrorCreateSubscription;
             var subscription = new Subscription(session.DefaultSubscription) { PublishingInterval = 1000 };
 
             Console.WriteLine("6 - Add a list of items (server current time and status) to the subscription.");
-            Environment.ExitCode = ERROR_MONITORED_ITEM;
+            Environment.ExitCode = (int)ExitCode.ErrorMonitoredItem;
             var list = new List<MonitoredItem> {
                 new MonitoredItem(subscription.DefaultItem)
                 {
@@ -261,12 +264,12 @@ namespace NetCoreConsoleClient
             subscription.AddItems(list);
 
             Console.WriteLine("7 - Add the subscription to the session.");
-            Environment.ExitCode = ERROR_ADD_SUBSCRIPTION;
+            Environment.ExitCode = (int)ExitCode.ErrorAddSubscription;
             session.AddSubscription(subscription);
             subscription.Create();
 
             Console.WriteLine("8 - Running...Press Ctrl-C to exit...");
-            Environment.ExitCode = ERROR_RUNNING;
+            Environment.ExitCode = (int)ExitCode.ErrorRunning;
 
             ManualResetEvent quitEvent = new ManualResetEvent(false);
             try
@@ -287,10 +290,10 @@ namespace NetCoreConsoleClient
             // return error conditions
             if (session.KeepAliveStopped)
             {
-                Environment.ExitCode = ERROR_NO_KEEPALIVE;
+                Environment.ExitCode = (int)ExitCode.ErrorNoKeepAlive;
                 return;
             }
-            Environment.ExitCode = ERROR_OK;
+            Environment.ExitCode = (int)ExitCode.Ok;
         }
 
         private static void OnNotification(MonitoredItem item, MonitoredItemNotificationEventArgs e)

--- a/SampleApplications/Samples/NetCoreConsoleServer/NetCoreConsoleServer.csproj
+++ b/SampleApplications/Samples/NetCoreConsoleServer/NetCoreConsoleServer.csproj
@@ -18,4 +18,14 @@
     <Folder Include="Properties\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Opc.Ua.SampleServer.Config.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/SampleApplications/Samples/NetCoreConsoleServer/Opc.Ua.SampleServer.Config.xml
+++ b/SampleApplications/Samples/NetCoreConsoleServer/Opc.Ua.SampleServer.Config.xml
@@ -14,7 +14,7 @@
     <!-- Where the application instance certificate is stored (MachineDefault) -->
     <ApplicationCertificate>
       <StoreType>X509Store</StoreType>
-      <StorePath>CurrentUser\UA_MachineDefault</StorePath>
+      <StorePath>CurrentUser\My</StorePath>
       <SubjectName>CN=UA Core Sample Server, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
     </ApplicationCertificate>
 

--- a/SampleApplications/Samples/NetCoreConsoleServer/Program.cs
+++ b/SampleApplications/Samples/NetCoreConsoleServer/Program.cs
@@ -73,7 +73,7 @@ namespace NetCoreConsoleServer
     public class Program
     {
 
-        public static void Main(string[] args)
+        public static int Main(string[] args)
         {
             Console.WriteLine(".Net Core OPC UA Console Server sample");
 
@@ -110,12 +110,13 @@ namespace NetCoreConsoleServer
 
                 Console.WriteLine("Options:");
                 options.WriteOptionDescriptions(Console.Out);
-                Environment.ExitCode = (int)ExitCode.ErrorInvalidCommandLine;
-                return; 
+                return (int)ExitCode.ErrorInvalidCommandLine;
             }
 
             MySampleServer server = new MySampleServer(autoAccept, stopTimeout);
             server.Run();
+
+            return (int)MySampleServer.ExitCode;
         }
     }
 
@@ -126,6 +127,7 @@ namespace NetCoreConsoleServer
         DateTime lastEventTime;
         int serverRunTime = Timeout.Infinite;
         static bool autoAccept = false;
+        static ExitCode exitCode;
 
         public MySampleServer(bool _autoAccept, int _stopTimeout)
         {
@@ -138,16 +140,16 @@ namespace NetCoreConsoleServer
 
             try
             {
-                Environment.ExitCode = (int)ExitCode.ErrorServerNotStarted;
+                exitCode = ExitCode.ErrorServerNotStarted;
                 ConsoleSampleServer().Wait();
                 Console.WriteLine("Server started. Press Ctrl-C to exit...");
-                Environment.ExitCode = (int)ExitCode.ErrorServerRunning;
+                exitCode = ExitCode.ErrorServerRunning;
             }
             catch (Exception ex)
             {
                 Utils.Trace("ServiceResultException:" + ex.Message);
                 Console.WriteLine("Exception: {0}", ex.Message);
-                Environment.ExitCode = (int)ExitCode.ErrorServerException;
+                exitCode = ExitCode.ErrorServerException;
                 return;
             }
 
@@ -180,8 +182,10 @@ namespace NetCoreConsoleServer
                 }
             }
 
-            Environment.ExitCode = (int)ExitCode.Ok;
+            exitCode = ExitCode.Ok;
         }
+
+        public static ExitCode ExitCode { get => exitCode; }
 
         private static void CertificateValidator_CertificateValidation(CertificateValidator validator, CertificateValidationEventArgs e)
         {

--- a/SampleApplications/Samples/NetCoreConsoleServer/Program.cs
+++ b/SampleApplications/Samples/NetCoreConsoleServer/Program.cs
@@ -10,14 +10,15 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
-using Opc.Ua;
-using Opc.Ua.Configuration;
-using Opc.Ua.Sample;
-using Opc.Ua.Server;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Mono.Options;
+using Opc.Ua;
+using Opc.Ua.Configuration;
+using Opc.Ua.Sample;
+using Opc.Ua.Server;
 
 namespace NetCoreConsoleServer
 {
@@ -62,9 +63,52 @@ namespace NetCoreConsoleServer
 
     public class Program
     {
+
+        private const int ERROR_OK = 0;
+        private const int ERROR_INVALID_COMMAND_LINE = 0x100;
+
         public static void Main(string[] args)
         {
-            MySampleServer server = new MySampleServer();
+            Console.WriteLine(".Net Core OPC UA Console Server sample");
+
+            // command line options
+            bool showHelp = false;
+            int stopTimeout = 0;
+            bool autoAccept = false;
+
+            Mono.Options.OptionSet options = new Mono.Options.OptionSet {
+                { "h|help", "show this message and exit", h => showHelp = h != null },
+                { "a|autoaccept", "auto accept certificates (for testing only)", a => autoAccept = a != null },
+                { "t|timeout=", "the number of seconds until the server stops.", (int t) => stopTimeout = t }
+            };
+
+            try
+            {
+                IList<string> extraArgs = options.Parse(args);
+                foreach (string extraArg in extraArgs)
+                {
+                    Console.WriteLine("Error: Unknown option: {0}", extraArg);
+                    showHelp = true;
+                }
+            }
+            catch (OptionException e)
+            {
+                Console.WriteLine(e.Message);
+                showHelp = true;
+            }
+
+            if (showHelp)
+            {
+                Console.WriteLine("Usage: dotnet NetCoreConsoleServer.dll [OPTIONS]");
+                Console.WriteLine();
+
+                Console.WriteLine("Options:");
+                options.WriteOptionDescriptions(Console.Out);
+                Environment.ExitCode = ERROR_INVALID_COMMAND_LINE;
+                return; 
+            }
+
+            MySampleServer server = new MySampleServer(autoAccept, stopTimeout);
             server.Run();
         }
     }
@@ -74,30 +118,51 @@ namespace NetCoreConsoleServer
         SampleServer server;
         Task status;
         DateTime lastEventTime;
+        int serverRunTime = Timeout.Infinite;
+        static bool autoAccept = false;
+        private const int ERROR_SERVER_NOT_STARTED = 0x80;
+        private const int ERROR_SERVER_RUNNING = 0x81;
+        private const int ERROR_OK = 0;
+
+
+        public MySampleServer(bool _autoAccept, int _stopTimeout)
+        {
+            autoAccept = _autoAccept;
+            serverRunTime = _stopTimeout == 0 ? Timeout.Infinite : _stopTimeout * 1000;
+        }
 
         public void Run()
         {
 
             try
             {
+                Environment.ExitCode = ERROR_SERVER_NOT_STARTED;
                 ConsoleSampleServer().Wait();
-                Console.WriteLine("Server started. Press any key to exit...");
+                Console.WriteLine("Server started. Press Ctrl-C to exit...");
+                Environment.ExitCode = ERROR_SERVER_RUNNING;
             }
             catch (Exception ex)
             {
                 Utils.Trace("ServiceResultException:" + ex.Message);
                 Console.WriteLine("Exception: {0}", ex.Message);
+                Environment.ExitCode = ERROR_SERVER_NOT_STARTED;
+                return;
             }
 
+            ManualResetEvent quitEvent = new ManualResetEvent(false);
             try
             {
-                Console.ReadKey(true);
+                Console.CancelKeyPress += (sender, eArgs) => {
+                    quitEvent.Set();
+                    eArgs.Cancel = true;
+                };
             }
             catch
             {
-                // wait forever if there is no console
-                Thread.Sleep(Timeout.Infinite);
             }
+
+            // wait for timeout or Ctrl-C
+            quitEvent.WaitOne(serverRunTime);
 
             if (server != null)
             {
@@ -112,13 +177,23 @@ namespace NetCoreConsoleServer
                     _server.Stop();
                 }
             }
+
+            Environment.ExitCode = ERROR_OK;
         }
+
         private static void CertificateValidator_CertificateValidation(CertificateValidator validator, CertificateValidationEventArgs e)
         {
             if (e.Error.StatusCode == StatusCodes.BadCertificateUntrusted)
             {
-                e.Accept = false;
-                Console.WriteLine("Rejected Certificate: {0}", e.Certificate.Subject);
+                e.Accept = autoAccept;
+                if (autoAccept)
+                {
+                    Console.WriteLine("Accepted Certificate: {0}", e.Certificate.Subject);
+                }
+                else
+                {
+                    Console.WriteLine("Rejected Certificate: {0}", e.Certificate.Subject);
+                }
             }
         }
 
@@ -187,7 +262,7 @@ namespace NetCoreConsoleServer
             }
         }
 
-        private void StatusThread()
+        private async void StatusThread()
         {
             while (server != null)
             {
@@ -201,7 +276,7 @@ namespace NetCoreConsoleServer
                     }
                     lastEventTime = DateTime.UtcNow;
                 }
-                Thread.Sleep(1000);
+                await Task.Delay(1000);
             }
         }
     }

--- a/SampleApplications/Samples/NetCoreConsoleServer/Program.cs
+++ b/SampleApplications/Samples/NetCoreConsoleServer/Program.cs
@@ -61,11 +61,17 @@ namespace NetCoreConsoleServer
         }
     }
 
+    public enum ExitCode : int
+    {
+        Ok = 0,
+        ErrorServerNotStarted = 0x80,
+        ErrorServerRunning = 0x81,
+        ErrorServerException = 0x82,
+        ErrorInvalidCommandLine = 0x100
+    };
+
     public class Program
     {
-
-        private const int ERROR_OK = 0;
-        private const int ERROR_INVALID_COMMAND_LINE = 0x100;
 
         public static void Main(string[] args)
         {
@@ -104,7 +110,7 @@ namespace NetCoreConsoleServer
 
                 Console.WriteLine("Options:");
                 options.WriteOptionDescriptions(Console.Out);
-                Environment.ExitCode = ERROR_INVALID_COMMAND_LINE;
+                Environment.ExitCode = (int)ExitCode.ErrorInvalidCommandLine;
                 return; 
             }
 
@@ -120,10 +126,6 @@ namespace NetCoreConsoleServer
         DateTime lastEventTime;
         int serverRunTime = Timeout.Infinite;
         static bool autoAccept = false;
-        private const int ERROR_SERVER_NOT_STARTED = 0x80;
-        private const int ERROR_SERVER_RUNNING = 0x81;
-        private const int ERROR_OK = 0;
-
 
         public MySampleServer(bool _autoAccept, int _stopTimeout)
         {
@@ -136,16 +138,16 @@ namespace NetCoreConsoleServer
 
             try
             {
-                Environment.ExitCode = ERROR_SERVER_NOT_STARTED;
+                Environment.ExitCode = (int)ExitCode.ErrorServerNotStarted;
                 ConsoleSampleServer().Wait();
                 Console.WriteLine("Server started. Press Ctrl-C to exit...");
-                Environment.ExitCode = ERROR_SERVER_RUNNING;
+                Environment.ExitCode = (int)ExitCode.ErrorServerRunning;
             }
             catch (Exception ex)
             {
                 Utils.Trace("ServiceResultException:" + ex.Message);
                 Console.WriteLine("Exception: {0}", ex.Message);
-                Environment.ExitCode = ERROR_SERVER_NOT_STARTED;
+                Environment.ExitCode = (int)ExitCode.ErrorServerException;
                 return;
             }
 
@@ -178,7 +180,7 @@ namespace NetCoreConsoleServer
                 }
             }
 
-            Environment.ExitCode = ERROR_OK;
+            Environment.ExitCode = (int)ExitCode.Ok;
         }
 
         private static void CertificateValidator_CertificateValidation(CertificateValidator validator, CertificateValidationEventArgs e)

--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -2048,7 +2048,7 @@ namespace Opc.Ua
                 {
                     if (String.IsNullOrEmpty(m_storeLocation))
                     {
-                        return Utils.Format("LocalMachine\\{0}", m_storeName);
+                        return Utils.Format("CurrentUser\\{0}", m_storeName);
                     }
 
                     return Utils.Format("{1}\\{0}", m_storeName, m_storeLocation);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,8 @@ clone_depth: 5                      # clone entire repository history if not def
 
 environment:
   matrix:
-  - solution_name: UA-NetStandard.sln
+  - solution_name: "UA Core Library.sln"
+  - solution_name: "UA-NetStandard.sln"
   - solution_name: "UA Global Discovery Server.sln"
   - solution_name: "UA Universal Windows.sln"
   - solution_name: "SampleApplications/Workshop/Aggregation/UA Aggregation.sln"
@@ -56,9 +57,13 @@ after_build:
 build_script:
   - msbuild "%solution_name%" /p:Configuration=Debug /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
   - msbuild "%solution_name%" /p:Configuration=Release /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-  
-# to disable automatic tests
+
+  # to disable automatic tests
 test: off
+
+# build cache to preserve files/folders between builds
+cache:
+  - packages -> **\packages.config  
 
 #---------------------------------#
 #        global handlers          #

--- a/testclientserver.sh
+++ b/testclientserver.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+echo Test the console server and console client
+workdir=$(pwd)
+testresult=0
+
+cd SampleApplications/Samples/NetCoreConsoleServer
+echo build server
+dotnet build
+echo start server
+dotnet run --no-restore --no-build -t 60 -a &
+serverpid="$!"
+cd $workdir
+
+cd SampleApplications/Samples/NetCoreConsoleClient
+echo build client
+dotnet build
+echo start client
+dotnet run --no-restore --no-build -t 20 &
+clientpid="$!"
+cd $workdir
+
+echo wait for client
+wait $clientpid
+if [ $? -eq 0 ]; then
+	echo "SUCCESS - Client test passed"
+else
+	testresult=$?
+	echo "FAILED - Client test failed with a status of $testresult"
+fi
+
+echo wait for server
+wait $serverpid
+serverresult=$?
+
+if [ $? -eq 0 ]; then
+	echo "SUCCESS - Server test passed"
+else
+	testresult=$?
+	echo "FAILED - Server test failed with a status of $testresult"
+fi
+
+exit $testresult
+
+
+


### PR DESCRIPTION
* Fix problem when X509Store CurrentUser\\UA_MachineDefault cannot be created on macOS with .NetStandard2.0 (#261)

Fix: Use CurrentUser\My instead for all machine certs to make console apps portable.

* add command line options to console sample apps for connection test, return proper error codes for testing
* update travis image to build also on macOS and to run a console client/server connection test
* run sample server and client as connection test
