### PR TITLE
Fix in ExpandedNodeId constructors 

### DIFF
--- a/Stack/Opc.Ua.Core/Types/BuiltIn/ExpandedNodeId.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/ExpandedNodeId.cs
@@ -56,7 +56,7 @@ namespace Opc.Ua
 
             if (value.m_nodeId != null)
             {
-                m_nodeId = value.m_nodeId;
+                m_nodeId = new NodeId(value.m_nodeId);
             }
         }
 
@@ -73,7 +73,7 @@ namespace Opc.Ua
 
             if (nodeId != null)
             {
-                m_nodeId = nodeId;
+                m_nodeId = new NodeId(nodeId);
             }
         }
 


### PR DESCRIPTION
 A clone of the input NodeId identifier should be created so it won't be changed from different places.