### PR TITLE
Update BuiltInTests.cs

### DIFF
--- a/Stack/Opc.Ua.Core/Types/BuiltIn/NodeId.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/NodeId.cs
@@ -925,7 +925,7 @@ namespace Opc.Ua
                         id2 = uid.Value;
                     }
 
-                    uint id1 = (uint)m_identifier;
+                    uint id1 = (uint)((m_identifier as uint?) ?? 0U);
 
                     if (id1 == id2)
                     {

--- a/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/BuiltInTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/BuiltInTests.cs
@@ -215,10 +215,21 @@ namespace Opc.Ua.Core.Tests.Types.BuiltIn
         #endregion
 
         #region NodeId utilities
-        [Test]
-        public void NodeIdComparison()
+        [Theory]
+        [TestCase(-1)]
+        public void NullIdNodeIdComparison(Opc.Ua.IdType idType)
         {
-            NodeId nodeId = new NodeId(0, 0);
+            NodeId nodeId = NodeId.Null;
+            switch (idType)
+            {
+                case Opc.Ua.IdType.Numeric: nodeId = new NodeId(0, 0); break;
+                case Opc.Ua.IdType.String: nodeId = new NodeId(""); break;
+                case Opc.Ua.IdType.Guid: nodeId = new NodeId(Guid.Empty); break;
+                case Opc.Ua.IdType.Opaque: nodeId = new NodeId((byte)0); break;
+            }
+
+            Assert.IsTrue(nodeId.IsNullNodeId);
+
             DataValue nodeIdBasedDataValue = new DataValue(nodeId);
 
             DataValue dataValue = new DataValue(Attributes.NodeClass);


### PR DESCRIPTION
A  new unit test which will currently fail, due to incorrect treatment of node ids with numeric identifier 0 in the namespace with index 0. ( "NodeId nodeId = new NodeId (0,0)." ).

Of course such a node id is invalid. It seems to be present, however, in some PLCs under certain situations. We encountered such node ids in the context of a customer ticket. The node ids were read into instance of type "DataValue" using the read service call. The evaluation of the read result then failed due to comparisons like the ones in the unit test.

#1610 is related to this.