### PR TITLE
[Server] Improve SubscriptionManager throughput by removing lock on subscription dictionary lookups

### DIFF
--- a/Libraries/Opc.Ua.Server/Subscription/SubscriptionManager.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/SubscriptionManager.cs
@@ -827,14 +827,19 @@ namespace Opc.Ua.Server
                 // create/update publish queue.
                 m_publishQueues.AddOrUpdate(
                     session.Id,
-                    new SessionPublishQueue(
-                        m_server,
-                        session,
-                        m_maxPublishRequestCount),
+                    (key) =>
+                    {
+                        var queue = new SessionPublishQueue(
+                            m_server,
+                            session,
+                            m_maxPublishRequestCount);
+
+                        queue.Add(subscription);
+                        return queue;
+                    },
                     (key, queue) =>
                         {
                             queue.Add(subscription);
-
                             return queue;
                         }
                 );


### PR DESCRIPTION
## Proposed changes

Improve SubscriptionManager throughput by removing lock on subscription dictionary lookups


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
