### PR TITLE
Fix: Update Dockerfile to target .NET 9.0 

### DIFF
--- a/Applications/ConsoleReferenceServer/Dockerfile
+++ b/Applications/ConsoleReferenceServer/Dockerfile
@@ -13,14 +13,14 @@ COPY ["Libraries/Opc.Ua.Configuration/Opc.Ua.Configuration.csproj", "Libraries/O
 COPY ["Libraries/Opc.Ua.Server/Opc.Ua.Server.csproj", "Libraries/Opc.Ua.Server/"]
 COPY ["Applications/Quickstarts.Servers/Quickstarts.Servers.csproj", "Applications/Quickstarts.Servers/"]
 ENV DOTNET_EnableWriteXorExecute=0
-RUN dotnet restore "Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj" --force -p:NoHttps=true -p:CustomTestTarget=net8.0
+RUN dotnet restore "Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj" --force -p:NoHttps=true -p:CustomTestTarget=net9.0
 COPY . .
 
 WORKDIR "/src/Applications/ConsoleReferenceServer"
 ARG Version
 ARG SimpleVersion
 ARG InformationalVersion
-ENV OPTIONS="-c Release -f net8.0 -p:NoHttps=true -p:Dockerbuild=true -p:Version=${Version} -p:AssemblyVersion=${SimpleVersion} -p:FileVersion=${Version} -p:InformationalVersion=${InformationalVersion} -p:CustomTestTarget=net8.0"
+ENV OPTIONS="-c Release -f net9.0 -p:NoHttps=true -p:Dockerbuild=true -p:Version=${Version} -p:AssemblyVersion=${SimpleVersion} -p:FileVersion=${Version} -p:InformationalVersion=${InformationalVersion} -p:CustomTestTarget=net9.0"
 
 FROM build AS publish
 ENV DOTNET_EnableWriteXorExecute=0


### PR DESCRIPTION
This PR addresses the issue described in #3245.

**Type of Issue:** Bug

**Current Behavior:**
When building a Docker image following the instructions in
[[ContainerReferenceServer.md](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/Docs/ContainerReferenceServer.md)](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/Docs/ContainerReferenceServer.md),
the resulting image (or the one hosted on GitHub) fails to run.
This occurs because the Dockerfile currently uses unversioned base images:

```
FROM mcr.microsoft.com/dotnet/runtime AS base
FROM mcr.microsoft.com/dotnet/sdk AS build
```

These pull the latest .NET (currently 9.0) images, while the environment variables are still configured for .NET 8.0.
As a result, the container fails to run due to version mismatch.

**Resolution:**
The project has been tested and verified to be compatible with .NET 9.0.
The environment options in the Dockerfile have been updated to target `.NET 9.0` accordingly.
This ensures compatibility with both .NET 9.0 and later versions.

**Expected Behavior:**
The container builds and runs successfully without errors.

**Steps to Reproduce:**

1. Build the Docker image using the existing instructions.
2. Observe that the container fails to start due to version mismatch.
3. With this fix applied, the container should run correctly using:

   ```
   FROM mcr.microsoft.com/dotnet/runtime:9.0 AS base
   FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
   ```