### PR TITLE
Fix console reference client cli args conflict

### DIFF
--- a/Applications/ConsoleReferenceClient/Program.cs
+++ b/Applications/ConsoleReferenceClient/Program.cs
@@ -184,7 +184,7 @@ namespace Quickstarts.ConsoleReferenceClient
                     }
                 },
                 {
-                    "f|fetchall",
+                    "fa|fetchall",
                     "Fetch all nodes",
                     f =>
                     {


### PR DESCRIPTION
## Proposed changes

Attempted to run the `ConsoleReferenceClient.csproj` using the following:

```bash
cd Applications/ConsoleReferenceClient
dotnet build ConsoleReferenceClient.csproj --framework "net10.0" --configuration Release
./bin/Release/net10.0/ConsoleReferenceClient -h
```

Got the following output:

```txt
OPC UA Console Reference Client
OPC UA library: 1.5.378.28 @ 12/04/2025 00:35:35 -- 1.5.378.28-preview+35e03d9067
Unhandled exception. System.ArgumentException: An item with the same key has already been added. Key: f
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at System.Collections.ObjectModel.KeyedCollection`2.InsertItem(Int32 index, TItem item)
   at Mono.Options.OptionSet.InsertItem(Int32 index, Option item)
   at Mono.Options.OptionSet.Add(String prototype, String description, Action`1 action, Boolean hidden)
   at Mono.Options.OptionSet.Add(String prototype, String description, Action`1 action)
   at Quickstarts.ConsoleReferenceClient.Program.Main(String[] args) in /Users/mohdfareed/Developer/opc-ua-dotnet/Applications/ConsoleReferenceClient/Program.cs:line 98
   at Quickstarts.ConsoleReferenceClient.Program.<Main>(String[] args)
./run-client.sh: line 7
```

Arguments `f|file` and `f|fetchall` conflict. Renamed the latter to `fa|fetchall`. The above exception is resolved.

## Related Issues

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

I could not figure out how to run the tests locally. I assume such a change is safe.
