### PR TITLE
Add event to update session when diagnostic counters changes

### DIFF
--- a/Libraries/Opc.Ua.Server/Session/ISessionManager.cs
+++ b/Libraries/Opc.Ua.Server/Session/ISessionManager.cs
@@ -59,6 +59,11 @@ namespace Opc.Ua.Server
         event SessionEventHandler SessionClosing;
 
         /// <summary>
+        /// Raised after diagnostics of an existing session were changed.
+        /// </summary>
+        event SessionEventHandler SessionDiagnosticsChanged;
+
+        /// <summary>
         /// Raised to signal a channel that the session is still alive.
         /// </summary>
         event SessionEventHandler SessionChannelKeepAlive;
@@ -141,6 +146,11 @@ namespace Opc.Ua.Server
         /// and that the sequence number is not out of order (update requests only).
         /// </remarks>
         OperationContext ValidateRequest(RequestHeader requestHeader, SecureChannelContext secureChannelContext, RequestType requestType);
+
+        /// <summary>
+        /// Triggers the <see cref="ISessionManager.SessionDiagnosticsChanged"/> event so subscribers can react.
+        /// </summary>
+        void RaiseSessionDiagnosticsChangedEvent(ISession session);
     }
 
     /// <summary>
@@ -193,6 +203,11 @@ namespace Opc.Ua.Server
         /// A session was activated and the user identity or preferred locales changed.
         /// </summary>
         Activated,
+
+        /// <summary>
+        /// The diagnostics of an existing session were changed.
+        /// </summary>
+        DiagnosticsChanged,
 
         /// <summary>
         /// A session is about to be closed.

--- a/Libraries/Opc.Ua.Server/Session/Session.cs
+++ b/Libraries/Opc.Ua.Server/Session/Session.cs
@@ -350,7 +350,6 @@ namespace Opc.Ua.Server
 
             lock (m_lock)
             {
-
                 if (secureChannelContext == null || !IsSecureChannelValid(secureChannelContext.SecureChannelId))
                 {
                     UpdateDiagnosticCounters(requestType, true, true);
@@ -1141,6 +1140,8 @@ namespace Opc.Ua.Server
             bool error,
             bool authorizationError)
         {
+            ServiceCounterDataType counter = null;
+
             lock (DiagnosticsLock)
             {
                 if (!error)
@@ -1159,8 +1160,6 @@ namespace Opc.Ua.Server
                         SessionDiagnostics.UnauthorizedRequestCount++;
                     }
                 }
-
-                ServiceCounterDataType counter = null;
 
                 switch (requestType)
                 {
@@ -1270,6 +1269,11 @@ namespace Opc.Ua.Server
                         counter.ErrorCount++;
                     }
                 }
+            }
+
+            if (counter != null)
+            {
+                m_server.SessionManager.RaiseSessionDiagnosticsChangedEvent(this);
             }
         }
 

--- a/Libraries/Opc.Ua.Server/Session/SessionManager.cs
+++ b/Libraries/Opc.Ua.Server/Session/SessionManager.cs
@@ -571,6 +571,17 @@ namespace Opc.Ua.Server
                 m_maxHistoryContinuationPoints);
         }
 
+        /// <inheritdoc />
+        public virtual void RaiseSessionDiagnosticsChangedEvent(ISession session)
+        {
+            if (session == null)
+            {
+                throw new ArgumentNullException(nameof(session));
+            }
+
+            RaiseSessionEvent(session, SessionEventReason.DiagnosticsChanged);
+        }
+
         /// <summary>
         /// Raises an event related to a session.
         /// </summary>
@@ -591,6 +602,9 @@ namespace Opc.Ua.Server
                         break;
                     case SessionEventReason.Closing:
                         handler = m_SessionClosing;
+                        break;
+                    case SessionEventReason.DiagnosticsChanged:
+                        handler = m_SessionDiagnosticsChanged;
                         break;
                     case SessionEventReason.ChannelKeepAlive:
                         handler = m_SessionChannelKeepAlive;
@@ -688,6 +702,7 @@ namespace Opc.Ua.Server
         private event SessionEventHandler m_SessionCreated;
         private event SessionEventHandler m_SessionActivated;
         private event SessionEventHandler m_SessionClosing;
+        private event SessionEventHandler m_SessionDiagnosticsChanged;
         private event SessionEventHandler m_SessionChannelKeepAlive;
         private event ImpersonateEventHandler m_ImpersonateUser;
         private event EventHandler<ValidateSessionLessRequestEventArgs> m_ValidateSessionLessRequest;
@@ -726,6 +741,25 @@ namespace Opc.Ua.Server
                 lock (m_eventLock)
                 {
                     m_SessionActivated -= value;
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public event SessionEventHandler SessionDiagnosticsChanged
+        {
+            add
+            {
+                lock (m_eventLock)
+                {
+                    m_SessionDiagnosticsChanged += value;
+                }
+            }
+            remove
+            {
+                lock (m_eventLock)
+                {
+                    m_SessionDiagnosticsChanged -= value;
                 }
             }
         }

--- a/Tests/Opc.Ua.Server.Tests/SessionTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/SessionTests.cs
@@ -1,0 +1,95 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Opc.Ua.Server.Tests
+{
+    [TestFixture]
+    [Category("Event")]
+    public class SessionTests
+    {
+        [Test]
+        public async Task UpdateDiagnosticCounters_RaisesEvent_WhenPerRequestCounterChanged()
+        {
+            var fixture = new ServerFixture<StandardServer>();
+            await fixture.StartAsync().ConfigureAwait(false);
+
+            try
+            {
+                StandardServer server = fixture.Server;
+
+                (RequestHeader requestHeader, SecureChannelContext secureChannelContext) =
+                    await ServerFixtureUtils.CreateAndActivateSessionAsync(server, "UpdateDiagnosticCountersTest").ConfigureAwait(false);
+
+                ISession session = server.CurrentInstance.SessionManager.GetSession(requestHeader.AuthenticationToken);
+                Assert.NotNull(session, "Session should exist after Create/Activate.");
+
+                bool eventRaised = false;
+
+                server.CurrentInstance.SessionManager.SessionDiagnosticsChanged += (s, reason)
+                    => eventRaised = true;
+
+                uint before = session.SessionDiagnostics.ReadCount.TotalCount;
+
+                // Call ValidateRequest for a request type that maps to a counter (Read).
+                session.ValidateRequest(requestHeader, secureChannelContext, RequestType.Read);
+
+                Assert.IsTrue(eventRaised, "SessionDiagnosticsChanged event should be raised when a per-request counter changes.");
+                Assert.Greater(session.SessionDiagnostics.ReadCount.TotalCount, before, "ReadCount.TotalCount should have incremented.");
+            }
+            finally
+            {
+                await fixture.StopAsync().ConfigureAwait(false);
+            }
+        }
+
+        [Test]
+        [Category("Event")]
+        [TestCase(RequestType.Unknown)]
+        [TestCase(RequestType.FindServers)]
+        [TestCase(RequestType.GetEndpoints)]
+        [TestCase(RequestType.CreateSession)]
+        [TestCase(RequestType.ActivateSession)]
+        [TestCase(RequestType.CloseSession)]
+        [TestCase(RequestType.Cancel)]
+        public async Task UpdateDiagnosticCounters_DoesNotRaiseEvent_ForIgnoredRequestTypes(RequestType requestType)
+        {
+            var fixture = new ServerFixture<StandardServer>();
+            await fixture.StartAsync().ConfigureAwait(false);
+
+            try
+            {
+                StandardServer server = fixture.Server;
+
+                (RequestHeader requestHeader, SecureChannelContext secureChannelContext) =
+                    await ServerFixtureUtils.CreateAndActivateSessionAsync(server, "UpdateDiagnosticCountersIgnoredTest").ConfigureAwait(false);
+
+                ISession session = server.CurrentInstance.SessionManager.GetSession(requestHeader.AuthenticationToken);
+                Assert.NotNull(session, "Session should exist after Create/Activate.");
+
+                bool eventRaised = false;
+
+                server.CurrentInstance.SessionManager.SessionDiagnosticsChanged += (s, reason)
+                    => eventRaised = true;
+
+                // Capture total requests before; UpdateDiagnosticCounters always increments TotalRequestCount.
+                uint totalBefore = session.SessionDiagnostics.TotalRequestCount.TotalCount;
+
+                // Call ValidateRequest with one of the ignored request types.
+                session.ValidateRequest(requestHeader, secureChannelContext, requestType);
+
+                Assert.AreEqual(
+                    totalBefore + 1,
+                    session.SessionDiagnostics.TotalRequestCount.TotalCount,
+                    "TotalRequestCount should increment for all request types.");
+
+                Assert.IsFalse(eventRaised, $"SessionDiagnosticsChanged event must NOT be raised for request type {requestType}.");
+            }
+            finally
+            {
+                await fixture.StopAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

The problem is that as a server, you don't automatically notice when something changes in a session. To avoid having to poll regularly at intervals, I introduced this event. It is triggered when the diagnostic counters of the session are updated. It also makes it easy to get the affected session updated. With polling, I would have to do this for every active session.

## Related Issues

- (Could open one if you don't want this change)

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [X] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
