### PR TITLE
Fix MinNonceLength for SecurityPolicies.Basic128Rsa15

### DIFF
--- a/Stack/Opc.Ua.Core/Security/Certificates/Nonce.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/Nonce.cs
@@ -312,6 +312,8 @@ namespace Opc.Ua
         {
             switch (securityPolicyUri)
             {
+                case SecurityPolicies.Basic128Rsa15:
+                    return 16;
                 case SecurityPolicies.Basic256:
                 case SecurityPolicies.Basic256Sha256:
                 case SecurityPolicies.Aes128_Sha256_RsaOaep:


### PR DESCRIPTION
## Proposed changes

Set NonceLength to 16 for [SecurityPolicies.Basic128Rsa15](http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15)

## Related Issues

- Fixes #3392

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
