### PR TITLE
[CI] Stabilize Connection stability test: Only run test on net 10, only print per node status in debug runs

### DIFF
--- a/.github/workflows/stability-test.yml
+++ b/.github/workflows/stability-test.yml
@@ -53,6 +53,7 @@ jobs:
         dotnet test ./Tests/Opc.Ua.Client.Tests/Opc.Ua.Client.Tests.csproj \
           --configuration ${{ env.CONFIGURATION }} \
           --no-build \
+          --framework ${{ env.DOTNET_VERSION }}
           --filter "Category=ConnectionStability" \
           --logger "console;verbosity=detailed" \
           --results-directory ./TestResults

--- a/Tests/Opc.Ua.Client.Tests/ConnectionStabilityTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ConnectionStabilityTest.cs
@@ -297,6 +297,7 @@ namespace Opc.Ua.Client.Tests
                             $"[Status Report {reportCount}] Elapsed: {elapsedMinutes} minutes, " +
                             $"Total notifications: {totalNotifications}, Write count: {writeCount}, Errors: {errors.Count}");
 
+#if DEBUG
                         // Report per-node statistics
                         if (reportCount % 5 == 0) // Every 5 minutes
                         {
@@ -306,6 +307,7 @@ namespace Opc.Ua.Client.Tests
                                 TestContext.Out.WriteLine($"  {kvp.Key}: {kvp.Value} notifications");
                             }
                         }
+#endif
                     }
                 }, statusReportingCts.Token);
 
@@ -362,7 +364,9 @@ namespace Opc.Ua.Client.Tests
                 {
                     if (valueChanges.TryGetValue(nodeId, out int changes))
                     {
+#if DEBUG
                         TestContext.Out.WriteLine($"  {nodeId}: {changes} notifications");
+#endif
                         if (changes < (writeCount * NotificationToleranceRatio))
                         {
                             allNodesReceivedData = false;

--- a/UA.slnx
+++ b/UA.slnx
@@ -69,6 +69,7 @@
     <File Path=".github/workflows/buildandtest.yml" />
     <File Path=".github/workflows/codeql-analysis.yml" />
     <File Path=".github/workflows/docker-image.yml" />
+    <File Path=".github/workflows/stability-test.yml" />
   </Folder>
   <Folder Name="/Solution Items/azurepipelines/">
     <File Path=".azurepipelines/ci.yml" />


### PR DESCRIPTION
## Proposed changes

Connection Stability Test failed on net 472 due to missing mono dependency.
Stabilize Connection stability test: Only run test on net 10, only print per node status in debug runs

## Related Issues

- Fixes #3423 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.