### PR TITLE
[Client] Fix format string in ValidateServerCertificateApplicationUri

### DIFF
--- a/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/CertificateValidator.cs
@@ -1923,7 +1923,7 @@ namespace Opc.Ua
                 {
                     return ServiceResult.Create(
                         StatusCodes.BadCertificateUriInvalid,
-                        "The Server Certificate ({1}) does not contain an applicationUri.",
+                        "The Server Certificate ({0}) does not contain an applicationUri.",
                         serverCertificate.Subject);
                 }
 


### PR DESCRIPTION
fix format string when create service result on validate server cert