### PR TITLE
Fix OperationLimits remarks

### DIFF
--- a/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Schema/ApplicationConfiguration.cs
@@ -755,7 +755,7 @@ namespace Opc.Ua
                 }
 
                 // If both legacy (<ApplicationCertificate>) and modern (<ApplicationCertificates>) elements
-                // are present during deserialization (as a consequence of previous serialization that included both unintentionally), 
+                // are present during deserialization (as a consequence of previous serialization that included both unintentionally),
                 // prefer the modern representation and clear the
                 // deprecated flag when we process the collection below.
 
@@ -2039,7 +2039,7 @@ namespace Opc.Ua
         /// Gets or sets the default operation limits of the OPC UA client.
         /// </summary>
         /// <remarks>
-        /// Values not equal to zero are overwritten with smaller values set by the server.
+        /// Values are overwritten with values set by the server.
         /// The values are used to limit client service calls.
         /// </remarks>
         [DataMember(IsRequired = false, Order = 6)]


### PR DESCRIPTION
With the changes in https://github.com/OPCFoundation/UA-.NETStandard/pull/3303 it seems that values are now always overwritten by values set in the server in FetchOperationLimitsAsync, rather than only in the case described in the remarks of OperationLimits.

## Proposed changes

Modify the Remarks of OperationLimits to be aligned with current functionality

## Related Issues

- #3303 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [x] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

N/A
