### PR TITLE
[Client] Modified Publish error handling to raise publish error events for BadNoSubscription if there are active subscriptions

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -2510,18 +2510,18 @@ namespace Opc.Ua.Client
         /// <summary>
         /// Recreate the subscriptions in a recreated session.
         /// </summary>
-        /// <param name="transferSbscriptionTemplates">Uses Transfer service
+        /// <param name="transferSubscriptionTemplates">Uses Transfer service
         /// if set to <c>true</c>.</param>
         /// <param name="subscriptionsTemplate">The template for the subscriptions.</param>
         /// <param name="ct">Cancellation token to cancel operation with</param>
         private async Task RecreateSubscriptionsAsync(
-            bool transferSbscriptionTemplates,
+            bool transferSubscriptionTemplates,
             IEnumerable<Subscription> subscriptionsTemplate,
             CancellationToken ct)
         {
             using Activity? activity = m_telemetry.StartActivity();
             bool transferred = false;
-            if (transferSbscriptionTemplates)
+            if (transferSubscriptionTemplates)
             {
                 try
                 {
@@ -3533,7 +3533,8 @@ namespace Opc.Ua.Client
                 // raise an error event.
                 var error = new ServiceResult(e);
 
-                if (error.Code != StatusCodes.BadNoSubscription)
+                // raise publish error even for BadNoSubscription if there are active subscriptions.
+                if (error.Code != StatusCodes.BadNoSubscription || m_subscriptions.Any(s => s.Created))
                 {
                     PublishErrorEventHandler? callback = m_PublishError;
 


### PR DESCRIPTION
## Proposed changes

- Modified Publish error handling to raise publish error events for BadNoSubscription if there are active subscriptions.
-  Fix typo in param name.

## Related Issues

- Fixes #

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.