### PR TITLE
[Server] Fix TransportChannel Response BadServiceUnsupported is never sent due to unhandled Exception when constructing EndpointIncomingRequest

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/EndpointBase.cs
@@ -1107,7 +1107,6 @@ namespace Opc.Ua
                 SecureChannelContext = context;
                 Request = request;
                 m_vts = ServiceResponsePooledValueTaskSource.Create();
-                m_service = m_endpoint.FindService(Request.TypeId);
                 m_cancellationToken = cancellationToken;
             }
 
@@ -1170,7 +1169,8 @@ namespace Opc.Ua
 
                     using (activity)
                     {
-                        IServiceResponse response = await m_service.InvokeAsync(Request, SecureChannelContext, linkedCts.Token).ConfigureAwait(false);
+                        ServiceDefinition service = m_endpoint.FindService(Request.TypeId);
+                        IServiceResponse response = await service.InvokeAsync(Request, SecureChannelContext, linkedCts.Token).ConfigureAwait(false);
                         m_vts.SetResult(response);
                     }
                 }
@@ -1232,7 +1232,6 @@ namespace Opc.Ua
             }
 
             private readonly EndpointBase m_endpoint;
-            private readonly ServiceDefinition m_service;
             private readonly ServiceResponsePooledValueTaskSource m_vts;
             private readonly CancellationToken m_cancellationToken;
         }


### PR DESCRIPTION
## Proposed changes

Fix EndpointIncomingRequest to do serviceLookup at invocation time in…stead of construction. This makes the object smaller and fixes a bug where the transport channel response was not sent due to unhandled exception

## Fixes

- #3504

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments
