### PR TITLE
[ConsoleReferenceClient] Fix Client_ReconnectComplete logic

### DIFF
--- a/Applications/ConsoleReferenceClient/UAClient.cs
+++ b/Applications/ConsoleReferenceClient/UAClient.cs
@@ -437,7 +437,20 @@ namespace Quickstarts
                             m_reconnectHandler.Session.SessionId
                         );
                         ISession session = Session;
+
+                        // Remove KeepAlive handler from old session before disposing
+                        session.KeepAlive -= Session_KeepAlive;
+
                         Session = m_reconnectHandler.Session;
+
+                        // Configure the new session with the same settings as initial connection
+                        Session.KeepAliveInterval = KeepAliveInterval;
+                        Session.DeleteSubscriptionsOnClose = false;
+                        Session.TransferSubscriptionsOnReconnect = true;
+
+                        // Register KeepAlive handler on the new session - this is critical for connection monitoring
+                        Session.KeepAlive += Session_KeepAlive;
+
                         Utils.SilentDispose(session);
                     }
                     else


### PR DESCRIPTION
* Re-register the KeepAlive handler on the new session.
* Re-apply session configuration (KeepAliveInterval, etc.).

## Proposed changes

Re-registering KeepAlive was missing in Client_ReconnectComplete 

## Related Issues

- Event handlers are instance-specific. When SessionReconnectHandler creates a new session, it's a new instance without the previous KeepAlive handler.
- Without re-registering, connection monitoring stops after reconnection.
- The reference code is an example and may not cover all production scenarios.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
