### PR TITLE
Respect configured RSA minimum certificate key size when creating RSA app certificates

### DIFF
--- a/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
+++ b/Libraries/Opc.Ua.Configuration/ApplicationInstance.cs
@@ -462,12 +462,13 @@ namespace Opc.Ua.Configuration
             {
                 if (!DisableCertificateAutoCreation)
                 {
-                    certificate = await CreateApplicationInstanceCertificateAsync(
-                            configuration,
-                            id,
-                            lifeTimeInMonths,
-                            ct)
-                        .ConfigureAwait(false);
+                certificate = await CreateApplicationInstanceCertificateAsync(
+                        configuration,
+                        id,
+                        minimumKeySize,
+                        lifeTimeInMonths,
+                        ct)
+                    .ConfigureAwait(false);
                 }
                 else
                 {
@@ -831,6 +832,7 @@ namespace Opc.Ua.Configuration
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="id">The certificate identifier.</param>
+        /// <param name="minimumKeySize">Minimum RSA key size to use when creating the certificate.</param>
         /// <param name="lifeTimeInMonths">The lifetime in months.</param>
         /// <param name="ct">Cancellation token to cancel operation with</param>
         /// <returns>The new certificate</returns>
@@ -838,6 +840,7 @@ namespace Opc.Ua.Configuration
         private async Task<X509Certificate2> CreateApplicationInstanceCertificateAsync(
             ApplicationConfiguration configuration,
             CertificateIdentifier id,
+            ushort minimumKeySize,
             ushort lifeTimeInMonths,
             CancellationToken ct)
         {
@@ -874,10 +877,16 @@ namespace Opc.Ua.Configuration
                 id.CertificateType == ObjectTypeIds.RsaMinApplicationCertificateType ||
                 id.CertificateType == ObjectTypeIds.RsaSha256ApplicationCertificateType)
             {
-                id.Certificate = builder.SetRSAKeySize(CertificateFactory.DefaultKeySize)
-                    .CreateForRSA();
+                ushort keySize = minimumKeySize == 0
+                    ? CertificateFactory.DefaultKeySize
+                    : minimumKeySize;
 
-                m_logger.LogInformation("Certificate {Certificate} created for RSA.", id.Certificate.AsLogSafeString());
+                id.Certificate = builder.SetRSAKeySize(keySize).CreateForRSA();
+
+                m_logger.LogInformation(
+                    "Certificate {Certificate} created for RSA with key size {KeySize} bits.",
+                    id.Certificate.AsLogSafeString(),
+                    keySize);
             }
             else
             {

--- a/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
+++ b/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
@@ -143,6 +143,48 @@ namespace Opc.Ua.Configuration.Tests
         }
 
         [Test]
+        public async Task TestNoFileConfigRespectsMinimumKeySizeOnCreationAsync()
+        {
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+
+            var applicationInstance = new ApplicationInstance(telemetry) { ApplicationName = ApplicationName };
+            Assert.NotNull(applicationInstance);
+
+            CertificateIdentifierCollection applicationCerts =
+                ApplicationConfigurationBuilder.CreateDefaultApplicationCertificates(
+                    SubjectName,
+                    CertificateStoreType.Directory,
+                    m_pkiRoot);
+
+            const ushort minimumKeySize = 4096;
+
+            ApplicationConfiguration config = await applicationInstance
+                .Build(ApplicationUri, ProductUri)
+                .AsClient()
+                .AddSecurityConfiguration(applicationCerts, m_pkiRoot)
+                .SetMinimumCertificateKeySize(minimumKeySize)
+                .CreateAsync()
+                .ConfigureAwait(false);
+            Assert.NotNull(config);
+
+            bool certOK = await applicationInstance
+                .CheckApplicationInstanceCertificatesAsync(true)
+                .ConfigureAwait(false);
+            Assert.True(certOK);
+
+            CertificateIdentifier certId = config.SecurityConfiguration.ApplicationCertificates[0];
+            X509Certificate2 certificate = await certId
+                .FindAsync(
+                    true,
+                    config.ApplicationUri,
+                    telemetry)
+                .ConfigureAwait(false);
+
+            Assert.NotNull(certificate);
+            Assert.AreEqual(minimumKeySize, X509Utils.GetPublicKeySize(certificate));
+        }
+
+        [Test]
         public async Task TestBadApplicationInstanceAsync()
         {
             ITelemetryContext telemetry = NUnitTelemetryContext.Create();


### PR DESCRIPTION
## Proposed changes

If a minimum RSA certificate key size is specified in the application configuration and no existing RSA application certificate is present the created application RSA certificate will have a key size equal to the specified MinimumCertificateKeySize configuration parameter.

## Related Issues

- Fixes #3512 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
