### PR TITLE
[CTT / ConsoleReferenceServer] Enforce numeric DataTypes for AnalogItem variables.

### DIFF
--- a/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
+++ b/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
@@ -4423,6 +4423,7 @@ namespace Quickstarts.ReferenceServer
             };
             variable.Value = GetNewValue(variable);
             variable.StatusCode = StatusCodes.Good;
+            variable.Description = "Default Description";
 
             if (valueRank == ValueRanks.OneDimension)
             {


### PR DESCRIPTION
## Proposed changes

Removed creation of non-numeric array AnalogItems and added a check to throw an exception if a non-numeric DataType is used. This ensures AnalogItems are restricted to numeric types, improving type safety and compliance.

Set default description to fix CTT Test, that expects that Description can be Read and not Return BadAttributeInvalid.


## Related Issues

- Fixes #3529
- Fixes #3528

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.