### PR TITLE
fix: Subscription diagnostic nodes not deleted when disabling diagnostics

### DIFF
--- a/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
@@ -642,7 +642,7 @@ namespace Opc.Ua.Server
                     {
                         for (int ii = 0; ii < m_subscriptions.Count; ii++)
                         {
-                            nodesToDelete.Add(m_sessions[ii].Value.Variable);
+                            nodesToDelete.Add(m_subscriptions[ii].Value.Variable);
                         }
 
                         m_subscriptions.Clear();


### PR DESCRIPTION
Fix a bug in `DiagnosticsNodeManager.SetDiagnosticsEnabled(false)` where the subscription cleanup loop indexes `m_sessions` instead of `m_subscriptions`. 

**Disclaimer:** This bug has been found with hours of manual work with AI and my local OPC UA stress test application and should be safe - please review the changes as I don't really know the OPC UA code base in depth.

## Bug

When `SetDiagnosticsEnabled(false)` is called, the subscription cleanup loop at line 643-646 iterates `m_subscriptions.Count` but indexes `m_sessions[ii]`:

```csharp
for (int ii = 0; ii < m_subscriptions.Count; ii++)
{
    nodesToDelete.Add(m_sessions[ii].Value.Variable); // should be m_subscriptions[ii]
}
```

This causes:
- **IndexOutOfRangeException** when there are more subscriptions than sessions, preventing any cleanup
- **Wrong nodes deleted** otherwise — session nodes are added to the delete list instead of subscription nodes

Subscription diagnostic nodes (and their child states and references) remain permanently in `PredefinedNodes`.
