### PR TITLE
Fix memory leaks in server disposal

### DIFF
--- a/Libraries/Opc.Ua.Server/Server/StandardServer.cs
+++ b/Libraries/Opc.Ua.Server/Server/StandardServer.cs
@@ -75,6 +75,11 @@ namespace Opc.Ua.Server
                     Utils.SilentDispose(m_serverInternal);
                     m_serverInternal = null;
                 }
+
+                if (CertificateValidator != null)
+                {
+                    CertificateValidator.CertificateUpdate -= OnCertificateUpdateAsync;
+                }
             }
 
             base.Dispose(disposing);

--- a/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/UaSCBinaryChannel.cs
@@ -226,6 +226,8 @@ namespace Opc.Ua.Bindings
             if (disposing)
             {
                 DiscardTokens();
+                Utils.SilentDispose(Socket);
+
                 m_localNonce?.Dispose();
                 m_localNonce = null;
 


### PR DESCRIPTION
Two related disposal bugs prevent the server object graph from being garbage collected after `StopAsync`/`Dispose` when clients were connected. Discovered during resilience testing of a long-running OPC UA server with repeated restart cycles (~2 MB leaked per cycle).

**Disclaimer:** This bug has been found with hours of manual work with AI and my local OPC UA stress test application and should be safe - please review the changes as I don't really know the OPC UA code base in depth.

### 1. `UaSCUaBinaryChannel.Dispose()` does not dispose the `Socket` property

Pending async I/O keeps the socket alive in `SocketAsyncEngine`, which retains the entire channel/listener graph and prevents GC. Fixed by adding `Utils.SilentDispose(Socket)` in `Dispose`.

Double-dispose is safe because `TcpMessageSocket.Close()` nulls `m_socket` before disposing, making subsequent `Dispose()` calls a no-op. `TcpServerChannel.Dispose()` acquires `DataLock`, preventing races with `ForceChannelFault`/`SendErrorMessage`.

### 2. `StandardServer.OnServerStarted()` subscribes `CertificateValidator.CertificateUpdate` but never unsubscribes

Since the `CertificateValidator` is shared (from `ApplicationConfiguration`) and outlives the server, the delegate retains every disposed server instance. Fixed by unsubscribing in `StandardServer.Dispose(bool)` inside the `disposing` guard.

## GC retention chains (before fix)

```
SocketAsyncEngine → Socket → TcpMessageSocket → TcpServerChannel
  → TcpTransportListener → m_callback → SessionEndpoint → Server

Socket → Channel → ChannelQuotas → CertificateValidator
  → CertificateUpdateEventHandler → Server
```

## Verification

Tested in a long-running OPC UA server with chaos testing (repeated server stop/start cycles with connected clients):

- **Before fix**: ~2 MB/cycle heap growth, retained server instances accumulating
- **After fix**: HeapMB stable (75–77 MB range over 22+ cycles), no retained server instances

## Notes

- Both fixes are inside existing `Dispose(bool)` methods, inside the `disposing` guard
- No behavioral changes during normal operation — only affects cleanup after disposal
- These bugs only manifest when servers are repeatedly created and destroyed within the same process (e.g., server restart loops). In single-lifecycle production deployments, process exit cleans everything up.