### PR TITLE
Fix TcpTransportListener resource leak in ServerBase.StopAsync

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
+++ b/Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs
@@ -545,7 +545,7 @@ namespace Opc.Ua
                 ServerError = new ServiceResult(e);
             }
 
-            // close any listeners.
+            // close and dispose any listeners.
             List<ITransportListener> listeners = TransportListeners;
 
             if (listeners != null)
@@ -563,6 +563,8 @@ namespace Opc.Ua
                             "Unexpected error closing a listener {Name}.",
                             listeners[ii].GetType().FullName);
                     }
+
+                    Utils.SilentDispose(listeners[ii]);
                 }
 
                 listeners.Clear();


### PR DESCRIPTION
`ServerBase.StopAsync()` calls `Close()` on each transport listener, then `Clear()` on the list. `ServerBase.Dispose()` later iterates `TransportListeners` to call `Dispose()` on each — but the list is already empty, so `TcpTransportListener.Dispose()` never runs.

This leaks per-listener resources that only `Dispose()` cleans up:

| Resource | `Close()` (via `Stop()`) | `Dispose()` |
|----------|--------------------------|-------------|
| `m_listeningSocket` | Disposed ✓ | Disposed ✓ |
| `m_listeningSocketIPv6` | Disposed ✓ | Disposed ✓ |
| `m_inactivityDetectionTimer` | **Not disposed** | Disposed ✓ |
| `m_channels` (all `TcpListenerChannel`s) | **Not disposed** | Disposed ✓ |

The bug is TCP-specific. The two `ITransportListener` implementations handle `Close()` differently:

- **`HttpsTransportListener`**: `Close()` → `Stop()` → `Dispose()` — `Close` already triggers full disposal
- **`TcpTransportListener`**: `Close()` → `Stop()` — only closes listening sockets, does **not** call `Dispose()`

So for TCP listeners, `Close()` stops accepting new connections but does not clean up existing channels or the inactivity detection timer. And the subsequent `listeners.Clear()` prevents `ServerBase.Dispose()` from ever reaching them.

**Disclaimer:** This bug has been found with hours of manual work with AI and my local OPC UA stress test application and should be safe - please review the changes as I don't really know the OPC UA code base in depth.

## Fix

Add `Utils.SilentDispose(listeners[ii])` after the existing `Close()` call in `StopAsync`. This ensures `TcpTransportListener.Dispose()` runs (cleaning up channels and timers) before the list is cleared.

For HTTPS listeners, the additional `Dispose()` is a harmless no-op since `Close()` already disposed everything. Both `TcpTransportListener.Dispose()` and `HttpsTransportListener.Dispose()` are idempotent (null-check-before-dispose pattern).

## Alternative

An alternative fix would be to remove the `listeners.Clear()` call from `StopAsync`, letting `ServerBase.Dispose()` handle disposal via its existing `Utils.SilentDispose` loop. However, this would leave already-closed listeners in the list between `StopAsync` and `Dispose`, which could be accessed by concurrent code paths (e.g., `OnCertificateUpdateAsync`, `SessionChannelKeepAliveEvent`). The chosen approach is more explicit: `StopAsync` fully cleans up listeners (Close + Dispose) and then clears the list, making it self-contained.

## Impact

Servers that call `StopAsync()` (the standard hosted service shutdown path) will now properly dispose TCP transport listener resources. Without this fix, each server stop/restart cycle leaks the inactivity detection timer and all active `TcpListenerChannel` instances (including their sockets, crypto state, and send/receive buffers).