### PR TITLE
[Client] Fixed freezing of Subscription with sequential publishing

### DIFF
--- a/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
@@ -51,7 +51,7 @@ namespace Opc.Ua.Client
         /// <summary>
         /// Duration to wait before republishing missed notification
         /// </summary>
-        public const int REPUBLISH_MESSAGE_TIMEOUT = 2500;
+        public const int RepublishMessageTimeout = 2500;
 
         /// <summary>
         /// Create subscription
@@ -1997,8 +1997,8 @@ namespace Opc.Ua.Client
                     // only republish consecutive sequence numbers
                     // triggers the republish mechanism immediately,
                     // if event is in the past
-                    DateTime now = DateTime.UtcNow.AddMilliseconds(-REPUBLISH_MESSAGE_TIMEOUT * 2);
-                    int tickCount = HiResClock.TickCount - (REPUBLISH_MESSAGE_TIMEOUT * 2);
+                    DateTime now = DateTime.UtcNow.AddMilliseconds(-RepublishMessageTimeout * 2);
+                    int tickCount = HiResClock.TickCount - (RepublishMessageTimeout * 2);
                     uint lastSequenceNumberToRepublish = m_lastSequenceNumberProcessed - 1;
                     int availableNumbers = availableSequenceNumbers.Count;
                     int republishMessages = 0;
@@ -2533,7 +2533,7 @@ namespace Opc.Ua.Client
                             // tolerate if a single request was received out of order
                             if (ii.Next.Next != null &&
                                 (HiResClock.TickCount -
-                                    ii.Value.TickCount) > REPUBLISH_MESSAGE_TIMEOUT)
+                                    ii.Value.TickCount) > RepublishMessageTimeout)
                             {
                                 ii.Value.Republished = true;
                                 publishStateChangedMask |= PublishStateChangedMask.Republish;

--- a/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
@@ -46,8 +46,12 @@ namespace Opc.Ua.Client
     {
         private const int kMinKeepAliveTimerInterval = 1000;
         private const int kKeepAliveTimerMargin = 1000;
-        private const int kRepublishMessageTimeout = 2500;
         private const int kRepublishMessageExpiredTimeout = 10000;
+
+        /// <summary>
+        /// Duration to wait before republishing missed notification
+        /// </summary>
+        public const int REPUBLISH_MESSAGE_TIMEOUT = 2500;
 
         /// <summary>
         /// Create subscription
@@ -1619,9 +1623,33 @@ namespace Opc.Ua.Client
 
                 // fill in any gaps in the queue
                 LinkedListNode<IncomingMessage>? node = m_incomingMessages.First;
+                if (node is not null)
+                {
+                    //gaps between m_lastSequenceNumberProcessed and starting node
+                    LinkedListNode<IncomingMessage> currentNode = node;
+                    for (uint i = node.Value.SequenceNumber; i > (m_lastSequenceNumberProcessed + 1); i--)
+                    {
+                        var placeholder = new IncomingMessage
+                        {
+                            SequenceNumber = i - 1,
+                            Timestamp = now,
+                            TickCount = tickCount
+                        };
+                        currentNode = m_incomingMessages.AddBefore(currentNode, placeholder);
+
+                        m_logger.LogInformation(
+                            "Session {SessionId}, subscription {SubscriptionName} ({SubscriptionId}): " +
+                            "added placeholder for missing incoming message with sequence number {MissingSequenceNumber}",
+                            Session?.SessionId,
+                            DisplayName,
+                            Id,
+                            placeholder.SequenceNumber);
+                    }
+                }
 
                 while (node != null)
                 {
+                    //gaps between neighbouring nodes
                     entry = node.Value;
                     LinkedListNode<IncomingMessage>? next = node.Next;
 
@@ -1969,8 +1997,8 @@ namespace Opc.Ua.Client
                     // only republish consecutive sequence numbers
                     // triggers the republish mechanism immediately,
                     // if event is in the past
-                    DateTime now = DateTime.UtcNow.AddMilliseconds(-kRepublishMessageTimeout * 2);
-                    int tickCount = HiResClock.TickCount - (kRepublishMessageTimeout * 2);
+                    DateTime now = DateTime.UtcNow.AddMilliseconds(-REPUBLISH_MESSAGE_TIMEOUT * 2);
+                    int tickCount = HiResClock.TickCount - (REPUBLISH_MESSAGE_TIMEOUT * 2);
                     uint lastSequenceNumberToRepublish = m_lastSequenceNumberProcessed - 1;
                     int availableNumbers = availableSequenceNumbers.Count;
                     int republishMessages = 0;
@@ -2505,7 +2533,7 @@ namespace Opc.Ua.Client
                             // tolerate if a single request was received out of order
                             if (ii.Next.Next != null &&
                                 (HiResClock.TickCount -
-                                    ii.Value.TickCount) > kRepublishMessageTimeout)
+                                    ii.Value.TickCount) > REPUBLISH_MESSAGE_TIMEOUT)
                             {
                                 ii.Value.Republished = true;
                                 publishStateChangedMask |= PublishStateChangedMask.Republish;

--- a/Tests/Opc.Ua.Client.Tests/SubscriptionUnitTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/SubscriptionUnitTests.cs
@@ -42,7 +42,6 @@ namespace Opc.Ua.Client.Tests
     [Parallelizable]
     public class SubscriptionUnitTests
     {
-        #region Utilities
         private class SubscriptionContainer : IDisposable
         {
             private readonly CancellationTokenRegistration m_tokedCancellation;
@@ -199,7 +198,6 @@ namespace Opc.Ua.Client.Tests
             await subscription.CreateAsync(cancellationToken).ConfigureAwait(false);
             return new(subscription, messageAwaiters, cancellationToken);
         }
-        #endregion Utilities
 
         /// <summary>
         /// Set up a Server and a Client instance.

--- a/Tests/Opc.Ua.Client.Tests/SubscriptionUnitTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/SubscriptionUnitTests.cs
@@ -71,7 +71,7 @@ namespace Opc.Ua.Client.Tests
 
         private static Task AwaitForRepublishTimeout(CancellationToken ct)
         {
-            return Task.Delay(Subscription.REPUBLISH_MESSAGE_TIMEOUT + 100, ct);
+            return Task.Delay(Subscription.RepublishMessageTimeout + 100, ct);
         }
 
         private static ISession BuildSessionMock(Func<uint, uint, bool> republishHandler)
@@ -219,7 +219,7 @@ namespace Opc.Ua.Client.Tests
 
         [Test]
         [Explicit("Test shows possibility for broken order of notifications during sequential publishing")]
-        [CancelAfter(Subscription.REPUBLISH_MESSAGE_TIMEOUT * 6)]
+        [CancelAfter(Subscription.RepublishMessageTimeout * 6)]
         public async Task UnorderedMessagesWouldBeLostForSequentialPublishingAsync(CancellationToken ct)
         {
             NotificationMessage[] messages = BuildMessages(5);
@@ -247,7 +247,7 @@ namespace Opc.Ua.Client.Tests
         }
 
         [Test]
-        [CancelAfter(Subscription.REPUBLISH_MESSAGE_TIMEOUT * 3)]
+        [CancelAfter(Subscription.RepublishMessageTimeout * 3)]
         public async Task WillRestoreOrderOfTwoMessagesForSequentialPublishingAsync(CancellationToken ct)
         {
             NotificationMessage[] messages = BuildMessages(3);
@@ -265,7 +265,7 @@ namespace Opc.Ua.Client.Tests
         }
 
         [Theory]
-        [CancelAfter(Subscription.REPUBLISH_MESSAGE_TIMEOUT * 7)]
+        [CancelAfter(Subscription.RepublishMessageTimeout * 7)]
         public async Task WillAbandonMissedMessagesIfThereAreNoAvailableSequenceNumbersAsync(bool sequentialPublishing, CancellationToken ct)
         {
             int[] sequenceNumbersToPublish = [/*1..2 gap*/ 3, 4, /*5..7 gap*/ 8, 9, 10];
@@ -292,7 +292,7 @@ namespace Opc.Ua.Client.Tests
         }
 
         [Theory]
-        [CancelAfter(Subscription.REPUBLISH_MESSAGE_TIMEOUT * 3)]
+        [CancelAfter(Subscription.RepublishMessageTimeout * 3)]
         public async Task WillRepublishIfMissedMessagesOnFirstPublishAsync(
             bool sequentialPublishing,
             [Values(2, 5, 8, 11)] int gapEnd,
@@ -320,7 +320,7 @@ namespace Opc.Ua.Client.Tests
         }
 
         [Theory]
-        [CancelAfter(Subscription.REPUBLISH_MESSAGE_TIMEOUT * 3)]
+        [CancelAfter(Subscription.RepublishMessageTimeout * 3)]
         public async Task WillRepublishIfMissedMessagesInBetweenOfPublishesAsync(
             bool sequentialPublishing,
             [Values(1, 6, 9)] int gapStart,

--- a/Tests/Opc.Ua.Client.Tests/SubscriptionUnitTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/SubscriptionUnitTests.cs
@@ -1,0 +1,356 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Opc.Ua.Tests;
+
+namespace Opc.Ua.Client.Tests
+{
+    [TestFixture]
+    [Parallelizable]
+    public class SubscriptionUnitTests
+    {
+        #region Utilities
+        private class SubscriptionContainer : IDisposable
+        {
+            private readonly CancellationTokenRegistration m_tokedCancellation;
+            public Subscription Subscription { get; }
+            public Task[] ProcessedMessages { get; }
+
+            public SubscriptionContainer(Subscription subscription, TaskCompletionSource<bool>[] awaiters, CancellationToken token)
+            {
+                Subscription = subscription;
+                ProcessedMessages = [.. awaiters.Select(x => x.Task)];
+                m_tokedCancellation = token.Register(() =>
+                {
+                    foreach (TaskCompletionSource<bool> awaiter in awaiters)
+                    {
+                        awaiter.TrySetCanceled();
+                    }
+                });
+            }
+
+            public void Dispose()
+            {
+                m_tokedCancellation.Dispose();
+                Subscription.Dispose();
+            }
+        }
+
+        private static Task AwaitForRepublishTimeout(CancellationToken ct)
+        {
+            return Task.Delay(Subscription.REPUBLISH_MESSAGE_TIMEOUT + 100, ct);
+        }
+
+        private static ISession BuildSessionMock(Func<uint, uint, bool> republishHandler)
+        {
+            uint subscriptionIdSeed = 0u;
+
+            var session = new Mock<ISession>();
+            session
+                .Setup(x => x.RepublishAsync(It.IsAny<uint>(), It.IsAny<uint>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync<uint, uint, CancellationToken, ISession, (bool, ServiceResult)>((
+                    subscriptionId,
+                    sequenceNumber,
+                    ct) =>
+                {
+                    if (subscriptionId > subscriptionIdSeed)
+                    {
+                        return (true, StatusCodes.BadSubscriptionIdInvalid);
+                    }
+                    if (republishHandler(subscriptionId, sequenceNumber))
+                    {
+                        return (true, ServiceResult.Good);
+                    }
+                    return (true, StatusCodes.BadMessageNotAvailable);
+                });
+            session
+                .Setup(x => x
+                    .CreateSubscriptionAsync(
+                        It.IsAny<RequestHeader>(),
+                        It.IsAny<double>(),
+                        It.IsAny<uint>(),
+                        It.IsAny<uint>(),
+                        It.IsAny<uint>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<byte>(),
+                        It.IsAny<CancellationToken>()
+                    )
+                )
+                .ReturnsAsync<
+                    RequestHeader,
+                    double,
+                    uint,
+                    uint,
+                    uint,
+                    bool,
+                    byte,
+                    CancellationToken,
+                    ISession,
+                    CreateSubscriptionResponse
+                    >((
+                        requestHeader,
+                        requestedPublishingInterval,
+                        requestedLifetimeCount,
+                        requestedMaxKeepAliveCount,
+                        maxNotificationsPerPublish,
+                        publishingEnabled,
+                        priority,
+                        ct
+                      ) => new() { SubscriptionId = ++subscriptionIdSeed });
+            session
+                .Setup(x => x.SetPublishingModeAsync(It.IsAny<RequestHeader>(), It.IsAny<bool>(), It.IsAny<UInt32Collection>(), It.IsAny<CancellationToken>())
+                )
+                .ReturnsAsync<
+                    RequestHeader,
+                    bool,
+                    UInt32Collection,
+                    CancellationToken,
+                    ISession,
+                    SetPublishingModeResponse
+                    >((requestHeader, publishingEnabled, subscriptionIds, ct) => new()
+                    {
+                        Results = [.. subscriptionIds.Select(id => id > subscriptionIdSeed ? StatusCodes.BadSubscriptionIdInvalid : StatusCodes.Good)],
+                        DiagnosticInfos = [.. subscriptionIds.Select(_ => new DiagnosticInfo())]
+                    });
+            return session.Object;
+        }
+
+        private static NotificationMessage[] BuildMessages(int count)
+        {
+            return Enumerable
+                .Range(1, count)
+                .Select(sequenceNumber => new NotificationMessage
+                {
+                    SequenceNumber = (uint)sequenceNumber,
+                    NotificationData = [new(new DataChangeNotification { SequenceNumber = (uint)sequenceNumber })]
+                })
+                .Prepend(new())//stub to compensate sequenceNumbers start from 1. Should be ignored
+                .ToArray();
+        }
+
+        private static async Task<SubscriptionContainer> BuildSubscriptionAsync(
+            NotificationMessage[] messagesToProcess,
+            bool sequentialPublishing,
+            CancellationToken cancellationToken)
+        {
+            TaskCompletionSource<bool>[] messageAwaiters = messagesToProcess
+                .Select(_ => new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously))
+                .ToArray();
+            messageAwaiters[0].SetResult(true);
+            List<uint> availableSequenceNumbers = [.. messagesToProcess.Skip(1).Select(x => x.SequenceNumber)];
+
+            var subscription = new Subscription(
+                NUnitTelemetryContext.Create(),
+                new()
+                {
+                    PublishingEnabled = true,
+                    SequentialPublishing = sequentialPublishing,
+                    MaxMessageCount = messagesToProcess.Length,
+                })
+            {
+                FastDataChangeCallback = (_, message, _) =>
+                {
+                    messageAwaiters[message.SequenceNumber].SetResult(true);
+                },
+            };
+            subscription.Session = BuildSessionMock((subscriptionId, sequenceNumber) =>
+            {
+                //simplified republish emulation
+                if (subscription.Id == subscriptionId && availableSequenceNumbers.Remove(sequenceNumber))
+                {
+                    subscription.SaveMessageInCache(null, messagesToProcess[sequenceNumber]);
+                    return true;
+                }
+                return false;
+            });
+            await subscription.CreateAsync(cancellationToken).ConfigureAwait(false);
+            return new(subscription, messageAwaiters, cancellationToken);
+        }
+        #endregion Utilities
+
+        /// <summary>
+        /// Set up a Server and a Client instance.
+        /// </summary>
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            TestContext.AddFormatter<NotificationMessage>((obj) =>
+            {
+                if (obj is NotificationMessage other)
+                {
+                    return $"{nameof(NotificationMessage)}: {other.SequenceNumber}";
+                }
+                return null;
+            });
+        }
+
+        [Test]
+        [Explicit("Test shows possibility for broken order of notifications during sequential publishing")]
+        [CancelAfter(Subscription.REPUBLISH_MESSAGE_TIMEOUT * 6)]
+        public async Task UnorderedMessagesWouldBeLostForSequentialPublishingAsync(CancellationToken ct)
+        {
+            NotificationMessage[] messages = BuildMessages(5);
+            using SubscriptionContainer container = await BuildSubscriptionAsync(messages, sequentialPublishing: true, ct).ConfigureAwait(false);
+            Subscription subscription = container.Subscription;
+
+            subscription.SaveMessageInCache([], messages[3]);
+            await AwaitForRepublishTimeout(ct).ConfigureAwait(false);
+            subscription.SaveMessageInCache([], messages[2]);//this one will be processed, because one message out of order is always awaited
+            await AwaitForRepublishTimeout(ct).ConfigureAwait(false);
+            subscription.SaveMessageInCache([], messages[4]);
+            await AwaitForRepublishTimeout(ct).ConfigureAwait(false);
+            subscription.SaveMessageInCache([], messages[1]);//this one should be lost due to expiration timout
+            await AwaitForRepublishTimeout(ct).ConfigureAwait(false);
+            subscription.SaveMessageInCache([], messages[5]);
+
+            await Task.WhenAll(
+                container.ProcessedMessages[2],
+                container.ProcessedMessages[3],
+                container.ProcessedMessages[4],
+                container.ProcessedMessages[5]
+                ).ConfigureAwait(false);
+
+            Assert.That(subscription.Notifications, Is.EqualTo([messages[2], messages[3], messages[4], messages[5]]));
+        }
+
+        [Test]
+        [CancelAfter(Subscription.REPUBLISH_MESSAGE_TIMEOUT * 3)]
+        public async Task WillRestoreOrderOfTwoMessagesForSequentialPublishingAsync(CancellationToken ct)
+        {
+            NotificationMessage[] messages = BuildMessages(3);
+            using SubscriptionContainer container = await BuildSubscriptionAsync(messages, sequentialPublishing: true, ct).ConfigureAwait(false);
+            Subscription subscription = container.Subscription;
+
+            subscription.SaveMessageInCache([], messages[2]);
+            await AwaitForRepublishTimeout(ct).ConfigureAwait(false);
+            subscription.SaveMessageInCache([], messages[1]);
+            await AwaitForRepublishTimeout(ct).ConfigureAwait(false);
+            subscription.SaveMessageInCache([], messages[3]);
+
+            await Task.WhenAll(container.ProcessedMessages).ConfigureAwait(false);
+            Assert.That(subscription.Notifications, Is.EqualTo(messages.Skip(1)));
+        }
+
+        [Theory]
+        [CancelAfter(Subscription.REPUBLISH_MESSAGE_TIMEOUT * 7)]
+        public async Task WillAbandonMissedMessagesIfThereAreNoAvailableSequenceNumbersAsync(bool sequentialPublishing, CancellationToken ct)
+        {
+            int[] sequenceNumbersToPublish = [/*1..2 gap*/ 3, 4, /*5..7 gap*/ 8, 9, 10];
+            NotificationMessage[] messages = BuildMessages(sequenceNumbersToPublish[^1]);
+            NotificationMessage[] messagesToPublish = [.. sequenceNumbersToPublish.Select(x => messages[x])];
+            using SubscriptionContainer container = await BuildSubscriptionAsync(messages, sequentialPublishing, ct).ConfigureAwait(false);
+            Subscription subscription = container.Subscription;
+
+            foreach (NotificationMessage message in messagesToPublish)
+            {
+                subscription.SaveMessageInCache([], message);
+                await AwaitForRepublishTimeout(ct).ConfigureAwait(false);
+            }
+            await Task.WhenAll(sequenceNumbersToPublish.Select(x => container.ProcessedMessages[x])).ConfigureAwait(false);
+
+            if (sequentialPublishing)
+            {
+                Assert.That(subscription.Notifications, Is.EqualTo(messagesToPublish));
+            }
+            else
+            {
+                Assert.That(subscription.Notifications, Is.EquivalentTo(messagesToPublish));
+            }
+        }
+
+        [Theory]
+        [CancelAfter(Subscription.REPUBLISH_MESSAGE_TIMEOUT * 3)]
+        public async Task WillRepublishIfMissedMessagesOnFirstPublishAsync(
+            bool sequentialPublishing,
+            [Values(2, 5, 8, 11)] int gapEnd,
+            CancellationToken ct)
+        {
+            int finalMessage = gapEnd + 1;
+            NotificationMessage[] messages = BuildMessages(finalMessage);
+            uint[] sequenceNumbersOfGap = [.. messages.Skip(1).Take(gapEnd).Select(x => x.SequenceNumber)];
+            using SubscriptionContainer container = await BuildSubscriptionAsync(messages, sequentialPublishing, ct).ConfigureAwait(false);
+            Subscription subscription = container.Subscription;
+
+            subscription.SaveMessageInCache(sequenceNumbersOfGap, messages[gapEnd]);
+            await AwaitForRepublishTimeout(ct).ConfigureAwait(false);
+            subscription.SaveMessageInCache(sequenceNumbersOfGap, messages[finalMessage]);
+            await Task.WhenAll(container.ProcessedMessages).ConfigureAwait(false);
+
+            if (sequentialPublishing)
+            {
+                Assert.That(subscription.Notifications, Is.EqualTo(messages.Skip(1)));
+            }
+            else
+            {
+                Assert.That(subscription.Notifications, Is.EquivalentTo(messages.Skip(1)));
+            }
+        }
+
+        [Theory]
+        [CancelAfter(Subscription.REPUBLISH_MESSAGE_TIMEOUT * 3)]
+        public async Task WillRepublishIfMissedMessagesInBetweenOfPublishesAsync(
+            bool sequentialPublishing,
+            [Values(1, 6, 9)] int gapStart,
+            [Values(1, 6, 9)] int gapSize,
+            CancellationToken ct)
+        {
+            int gapEnd = gapStart + gapSize + 1;
+            int finalMessage = gapEnd + 1;
+            NotificationMessage[] messages = BuildMessages(finalMessage);
+            uint[] sequenceNumbersOfGap = [.. messages.Skip(1).Skip(gapStart).Take(gapSize).Select(x => x.SequenceNumber)];
+            using SubscriptionContainer container = await BuildSubscriptionAsync(messages, sequentialPublishing, ct).ConfigureAwait(false);
+            Subscription subscription = container.Subscription;
+
+            for (int i = 1; i <= gapStart; i++)
+            {
+                subscription.SaveMessageInCache([], messages[i]);
+            }
+            subscription.SaveMessageInCache(sequenceNumbersOfGap, messages[gapEnd]);
+            await AwaitForRepublishTimeout(ct).ConfigureAwait(false);
+            subscription.SaveMessageInCache(sequenceNumbersOfGap, messages[finalMessage]);
+            await Task.WhenAll(container.ProcessedMessages).ConfigureAwait(false);
+
+            if (sequentialPublishing)
+            {
+                Assert.That(subscription.Notifications, Is.EqualTo(messages.Skip(1)));
+            }
+            else
+            {
+                Assert.That(subscription.Notifications, Is.EquivalentTo(messages.Skip(1)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug

The client subscription fails to move messages from ```Subscription.m_incomingMessages``` to ```Subscription.m_messageCache```, which leads to a complete **freeze** of the subscription publishing state.

#### Conditions Required to Reproduce
The issue occurs only when **both** of the following are met:
* ```Subscription.SequentialPublishing = true```
* ```Subscription.SaveMessageInCache``` receives the first message with a ```SequenceNumber``` greater than ```1``` (```availableSequenceNumbers``` is not relevant in this scenario)
#### Root Cause
When **sequential publishing** is enabled, the subscription cannot process incoming messages if there is a gap in sequence numbers.

```Subscription.SaveMessageInCache``` already contains logic to handle gaps between messages. However, it does **not** handle the specific case where the *first received message* itself introduces the gap (i.e., when the sequence does not start from ```1```).

As a result:

* Sequential subscriptions become blocked due to the unresolved gap.
* For non-sequential subscriptions, republishing of initially missed messages may be skipped.

## Proposed changes

* Added additional logic in ```Subscription.SaveMessageInCache``` to properly fill the gap between ```Subscription.m_lastSequenceNumberProcessed``` and ```IncomingMessage.SequenceNumber```
* Added several unit tests in ```SubscriptionUnitTests``` to validate scenarios involving unordered messages passed to ```Subscription.SaveMessageInCache```.

## Notes
* The bug is difficult to reproduce in real-world environments but can be reliably reproduced in isolated unit tests.
* While writing the tests, an additional edge case was discovered: a message with an already processed ```SequenceNumber``` can be sent (see test ```UnorderedMessagesWouldBeLostForSequentialPublishingAsync```).
In this case, the subscription treats such a message as the latest received message.
This appears to be another bug. For now, the corresponding test is marked as [Explicit] for further investigation.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [x] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
