### PR TITLE
Use the cancelation token in frameworks where available

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
+++ b/Stack/Opc.Ua.Core/Stack/Tcp/TcpMessageSocket.cs
@@ -323,7 +323,11 @@ namespace Opc.Ua.Bindings
             };
             try
             {
+#if NET5_0_OR_GREATER
+                await socket.ConnectAsync(endpoint, ct).ConfigureAwait(false);
+#else
                 await socket.ConnectAsync(endpoint).ConfigureAwait(false);
+#endif
 
                 ct.ThrowIfCancellationRequested();
                 lock (m_socketLock)


### PR DESCRIPTION
## Proposed changes

The Method CoreClientUtils.SelectEndpointAsync() does not react to the cancelation token. 
If the process is aborted by canceling the token, the full timeout does get awaited. 

In newer framworks the method ConnectAsync() does accept a cancelation token and react correctly. 
At least there should the correct version be used.

## Related Issues

- Fixes reaction to cancelation token.

## Types of changes

What types of changes does your code introduce?

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

