### PR TITLE
Backport reconnect user token policy reuse to master378

### DIFF
--- a/Libraries/Opc.Ua.Client/Session/Session.cs
+++ b/Libraries/Opc.Ua.Client/Session/Session.cs
@@ -1278,6 +1278,8 @@ namespace Opc.Ua.Client
                     previousServerNonce,
                     m_endpoint.Description.SecurityMode);
 
+                m_userTokenSecurityPolicyUri = tokenSecurityPolicyUri;
+
                 // sign data with user token.
                 SignatureData userTokenSignature = identityToken.Sign(
                     dataToSign,
@@ -2321,7 +2323,7 @@ namespace Opc.Ua.Client
                 UserTokenPolicy identityPolicy = endpoint.FindUserTokenPolicy(
                     m_identity.TokenType,
                     m_identity.IssuedTokenType,
-                    endpoint.SecurityPolicyUri);
+                    m_userTokenSecurityPolicyUri ?? endpoint.SecurityPolicyUri);
 
                 if (identityPolicy == null)
                 {
@@ -2334,18 +2336,25 @@ namespace Opc.Ua.Client
                 }
 
                 // select the security policy for the user token.
-                string? tokenSecurityPolicyUri = identityPolicy.SecurityPolicyUri;
-                if (string.IsNullOrEmpty(tokenSecurityPolicyUri))
+                if (m_userTokenSecurityPolicyUri == null)
                 {
-                    tokenSecurityPolicyUri = endpoint.SecurityPolicyUri;
+                    string? tokenSecurityPolicyUri = identityPolicy.SecurityPolicyUri;
+                    if (string.IsNullOrEmpty(tokenSecurityPolicyUri))
+                    {
+                        tokenSecurityPolicyUri = endpoint.SecurityPolicyUri;
+                    }
+
+                    m_userTokenSecurityPolicyUri = tokenSecurityPolicyUri;
                 }
-                m_userTokenSecurityPolicyUri = tokenSecurityPolicyUri;
+
+                string userTokenSecurityPolicyUri =
+                    m_userTokenSecurityPolicyUri ?? endpoint.SecurityPolicyUri;
 
                 // validate server nonce and security parameters for user identity.
                 ValidateServerNonce(
                     m_identity,
                     m_serverNonce,
-                    tokenSecurityPolicyUri,
+                    userTokenSecurityPolicyUri,
                     m_previousServerNonce,
                     m_endpoint.Description.SecurityMode);
 
@@ -2354,7 +2363,7 @@ namespace Opc.Ua.Client
                 identityToken.PolicyId = identityPolicy.PolicyId;
                 SignatureData userTokenSignature = identityToken.Sign(
                     dataToSign,
-                    tokenSecurityPolicyUri,
+                    userTokenSecurityPolicyUri,
                     m_telemetry);
 
                 // encrypt token.

--- a/Tests/Opc.Ua.Client.Tests/ClientTest.cs
+++ b/Tests/Opc.Ua.Client.Tests/ClientTest.cs
@@ -970,6 +970,74 @@ namespace Opc.Ua.Client.Tests
         }
 
         /// <summary>
+        /// Open a session on a channel using a usertokenpolicy from another endpoint, then reconnect (activate)
+        /// </summary>
+        [Test]
+        [Order(260)]
+        [TestCase(SecurityPolicies.Basic256Sha256, SecurityPolicies.Basic128Rsa15)]
+        public async Task ReconnectSession_ReuseUsertokenPolicyAsync(
+            string securityPolicy, string userTokenPolicy)
+        {
+            UserIdentity userIdentity = new UserIdentity("user1", "password"u8);
+
+            // the first channel determines the endpoint
+            ConfiguredEndpoint endpoint = await ClientFixture
+                .GetEndpointAsync(ServerUrl, securityPolicy, Endpoints)
+                .ConfigureAwait(false);
+            if (endpoint == null)
+            {
+                NUnit.Framework.Assert.Ignore(
+                    $"No endpoint found for {securityPolicy}");
+            }
+            endpoint = new ConfiguredEndpoint(
+                null,
+                (EndpointDescription)endpoint.Description.MemberwiseClone(),
+                endpoint.Configuration);
+            ConfiguredEndpoint tokenPolicyEndpoint = await ClientFixture
+                .GetEndpointAsync(ServerUrl, userTokenPolicy, Endpoints)
+                .ConfigureAwait(false);
+            Assert.NotNull(tokenPolicyEndpoint);
+
+            UserTokenPolicy identityPolicy = endpoint.Description.FindUserTokenPolicy(
+                userIdentity.TokenType,
+                userIdentity.IssuedTokenType,
+                tokenPolicyEndpoint.Description.SecurityPolicyUri);
+            if (identityPolicy == null)
+            {
+                NUnit.Framework.Assert.Ignore(
+                    $"No UserTokenPolicy found for {userIdentity.TokenType}" +
+                    $" / {userIdentity.IssuedTokenType}");
+            }
+            if (!string.IsNullOrEmpty(identityPolicy.SecurityPolicyUri) &&
+                identityPolicy.SecurityPolicyUri != userTokenPolicy)
+            {
+                Assert.Fail(
+                    $"UserTokenPolicy SecurityPolicyUri {identityPolicy.SecurityPolicyUri} does not match test expected SecurityPolicyUri {userTokenPolicy} " +
+                    "Please fix Test parameters or Test server configuration");
+            }
+            userIdentity.PolicyId = identityPolicy.PolicyId;
+
+            // the active channel
+            ISession session1 = await ClientFixture.ConnectAsync(endpoint, userIdentity)
+                .ConfigureAwait(false);
+            Assert.NotNull(session1);
+            try
+            {
+                await session1.ReconnectAsync(null, null).ConfigureAwait(false);
+                Assert.AreEqual(
+                    identityPolicy.PolicyId,
+                    session1.Identity.PolicyId,
+                    "User Token PolicyId needs to be preserved after reconnect.");
+            }
+            finally
+            {
+                session1.DeleteSubscriptionsOnClose = true;
+                await session1.CloseAsync(1000).ConfigureAwait(false);
+                Utils.SilentDispose(session1);
+            }
+        }
+
+        /// <summary>
         /// Open a session on a channel, then recreate using the session as a template,
         /// verify the renewUserIdentityHandler is brought to the new session and called
         /// before Session.Open


### PR DESCRIPTION
Backport the reconnect/reactivate fix from 36dc85b to master378.

## Proposed changes

Describe the changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
