### PR TITLE
Enhance role-based access control and add permission tests

### DIFF
--- a/Libraries/Opc.Ua.Server/Configuration/SystemConfigurationIdentity.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/SystemConfigurationIdentity.cs
@@ -43,7 +43,7 @@ namespace Opc.Ua.Server
         /// </summary>
         /// <param name="identity">The user identity.</param>
         public SystemConfigurationIdentity(IUserIdentity identity)
-            : base(identity, [Role.SecurityAdmin, Role.ConfigureAdmin], new NamespaceTable())
+            : base(identity, [Role.SecurityAdmin, Role.ConfigureAdmin, Role.AuthenticatedUser], new NamespaceTable())
         {
         }
     }

--- a/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/DiagnosticsNodeManager.cs
@@ -1512,6 +1512,7 @@ namespace Opc.Ua.Server
             }
             else
             {
+                // allow Session to see own session diagnostics
                 NodeId curSession = (context as ISessionSystemContext)?.SessionId ?? default;
                 adminUser = node.NodeId == curSession || HasApplicationSecureAdminAccess(context);
             }
@@ -1526,8 +1527,7 @@ namespace Opc.Ua.Server
                         Permissions = (uint)(
                             PermissionType.Browse |
                             PermissionType.Read |
-                            PermissionType.ReadRolePermissions |
-                            PermissionType.Write)
+                            PermissionType.ReadRolePermissions)
                     };
 
                 value = [.. rolePermissionTypes];
@@ -1660,11 +1660,7 @@ namespace Opc.Ua.Server
                     return false;
                 }
 
-                IUserIdentity user = session.UserIdentity as RoleBasedIdentity;
-
-                return user != null &&
-                    user.TokenType != UserTokenType.Anonymous &&
-                    user.GrantedRoleIds.Contains(ObjectIds.WellKnownRole_SecurityAdmin);
+                return session?.UserIdentity?.GrantedRoleIds.Contains(ObjectIds.WellKnownRole_SecurityAdmin) == true;
             }
             return false;
         }
@@ -2118,6 +2114,7 @@ namespace Opc.Ua.Server
         [
             ObjectIds.WellKnownRole_Anonymous,
             ObjectIds.WellKnownRole_AuthenticatedUser,
+            ObjectIds.WellKnownRole_TrustedApplication,
             ObjectIds.WellKnownRole_ConfigureAdmin,
             ObjectIds.WellKnownRole_Engineer,
             ObjectIds.WellKnownRole_Observer,

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -1120,7 +1120,8 @@ namespace Opc.Ua.Server
                         ServiceResult serviceResult = ValidateRolePermissions(
                             context,
                             nodeMetadata,
-                            PermissionType.Browse);
+                            PermissionType.Browse,
+                            m_logger);
 
                         if (ServiceResult.IsBad(serviceResult))
                         {
@@ -1331,24 +1332,38 @@ namespace Opc.Ua.Server
             out Dictionary<NodeId, Variant[]> uniqueNodesServiceAttributes)
         {
             var uniqueNodes = new HashSet<NodeId>();
+            Type listType = typeof(T);
+
+            if (listType != typeof(ReadValueId) &&
+                listType != typeof(BrowseDescription) &&
+                listType != typeof(CallMethodRequest))
+            {
+                throw new ArgumentException(
+                    "Provided List<T> nodesCollection is of wrong type, T should be type BrowseDescription, ReadValueId or CallMethodRequest",
+                    nameof(nodesList));
+            }
+
             for (int i = 0; i < nodesList.Count; i++)
             {
-                Type listType = typeof(T);
                 NodeId nodeId = default;
 
                 if (listType == typeof(ReadValueId))
                 {
                     nodeId = (nodesList[i] as ReadValueId)?.NodeId ?? default;
                 }
-
-                if (nodeId.IsNull)
+                else if (listType == typeof(BrowseDescription))
                 {
-                    throw new ArgumentException(
-                        "Provided List<T> nodesCollection is of wrong type, T should be type BrowseDescription, ReadValueId or CallMethodRequest",
-                        nameof(nodesList));
+                    nodeId = (nodesList[i] as BrowseDescription)?.NodeId ?? default;
+                }
+                else if (listType == typeof(CallMethodRequest))
+                {
+                    nodeId = (nodesList[i] as CallMethodRequest)?.ObjectId ?? default;
                 }
 
-                uniqueNodes.Add(nodeId);
+                if (!nodeId.IsNull)
+                {
+                    uniqueNodes.Add(nodeId);
+                }
             }
             // uniqueNodesReadAttributes is the place where the attributes for each unique nodeId are kept on the services
             uniqueNodesServiceAttributes = [];
@@ -2634,7 +2649,8 @@ namespace Opc.Ua.Server
                     errors[ii] = ValidateRolePermissions(
                         context,
                         nodeMetadata,
-                        PermissionType.ReceiveEvents);
+                        PermissionType.ReceiveEvents,
+                        m_logger);
 
                     if (ServiceResult.IsBad(errors[ii]))
                     {
@@ -3739,7 +3755,8 @@ namespace Opc.Ua.Server
                     serviceResult = ValidateRolePermissions(
                         context,
                         nodeMetadata,
-                        requestedPermision);
+                        requestedPermision,
+                        m_logger);
 
                     if (ServiceResult.IsGood(serviceResult))
                     {
@@ -3830,7 +3847,8 @@ namespace Opc.Ua.Server
         protected internal static ServiceResult ValidateRolePermissions(
             OperationContext context,
             NodeMetadata nodeMetadata,
-            PermissionType requestedPermission)
+            PermissionType requestedPermission,
+            ILogger logger = null)
         {
             if (nodeMetadata == null || requestedPermission == PermissionType.None)
             {
@@ -3879,7 +3897,7 @@ namespace Opc.Ua.Server
                     else
                     {
                         roleIdPermissions[rolePermission.RoleId] =
-                            ((PermissionType)rolePermission.Permissions) & requestedPermission;
+                            (PermissionType)rolePermission.Permissions;
                     }
                 }
             }
@@ -3898,7 +3916,7 @@ namespace Opc.Ua.Server
                     else
                     {
                         roleIdPermissionsDefinedForUser[rolePermission.RoleId] =
-                            ((PermissionType)rolePermission.Permissions) & requestedPermission;
+                            (PermissionType)rolePermission.Permissions;
                     }
                 }
             }
@@ -3932,20 +3950,33 @@ namespace Opc.Ua.Server
             ArrayOf<NodeId> currentRoleIds = context?.UserIdentity?.GrantedRoleIds ?? default;
             if (currentRoleIds.IsEmpty)
             {
+                logger?.LogDebug("Current user has no granted role.");
                 return ServiceResult.Create(
                     StatusCodes.BadUserAccessDenied,
                     "Current user has no granted role.");
             }
 
+            PermissionType userActualPermissions = PermissionType.None;
+
             foreach (NodeId currentRoleId in currentRoleIds)
             {
-                if (commonRoleIdPermissions.TryGetValue(currentRoleId, out PermissionType value) &&
-                    value != PermissionType.None)
+                if (commonRoleIdPermissions.TryGetValue(currentRoleId, out PermissionType value))
                 {
-                    // there is one role that current session has na is listed in requested role
-                    return StatusCodes.Good;
+                    userActualPermissions |= value;
+                    if ((value & requestedPermission) != PermissionType.None)
+                    {
+                        // there is one role that current session has na is listed in requested role
+                        return StatusCodes.Good;
+                    }
                 }
             }
+
+            logger?.LogDebug(
+                "Role permissions validation failed for node {NodeId}. Requested: {RequestedPermission}, User has: {UserPermissions}",
+                nodeMetadata.NodeId,
+                requestedPermission,
+                userActualPermissions);
+
             return ServiceResult.Create(
                 StatusCodes.BadUserAccessDenied,
                 "The requested permission {0} is not granted for node id {1}.",

--- a/Libraries/Opc.Ua.Server/RoleBasedUserManagement/RoleBasedIdentity.cs
+++ b/Libraries/Opc.Ua.Server/RoleBasedUserManagement/RoleBasedIdentity.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Xml;
@@ -53,6 +54,12 @@ namespace Opc.Ua.Server
         /// </summary>
         public static Role AuthenticatedUser { get; } =
             new Role(ObjectIds.WellKnownRole_AuthenticatedUser, BrowseNames.WellKnownRole_AuthenticatedUser);
+
+        /// <summary>
+        /// The Role is allowed to browse and read non-security related Nodes.
+        /// </summary>
+        public static Role TrustedApplication { get; } =
+            new Role(ObjectIds.WellKnownRole_TrustedApplication, BrowseNames.WellKnownRole_TrustedApplication);
 
         /// <summary>
         /// The Role is allowed to browse, read live data, read historical data/events or subscribe to data/events.
@@ -191,10 +198,17 @@ namespace Opc.Ua.Server
         {
             m_identity = identity;
             Roles = roles;
+
+            if (identity is RoleBasedIdentity roleBasedIdentity)
+            {
+                Roles = roleBasedIdentity.Roles.Concat(roles);
+            }
+
             GrantedRoleIds = identity.GrantedRoleIds
                 .AddItems(roles
-                .Where(role => role != null)
+                .Where(role => role != null && !role.RoleId.IsNull)
                 .Select(role => ExpandedNodeId.ToNodeId(role.RoleId, namespaces))
+                .Where(roleID => !identity.GrantedRoleIds.Contains(roleID))
                 .ToArrayOf());
         }
 

--- a/Libraries/Opc.Ua.Server/RoleBasedUserManagement/RoleBasedIdentity.cs
+++ b/Libraries/Opc.Ua.Server/RoleBasedUserManagement/RoleBasedIdentity.cs
@@ -29,7 +29,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Xml;
@@ -206,7 +205,7 @@ namespace Opc.Ua.Server
 
             GrantedRoleIds = identity.GrantedRoleIds
                 .AddItems(roles
-                .Where(role => role != null && !role.RoleId.IsNull)
+                .Where(role => role != null)
                 .Select(role => ExpandedNodeId.ToNodeId(role.RoleId, namespaces))
                 .Where(roleID => !identity.GrantedRoleIds.Contains(roleID))
                 .ToArrayOf());

--- a/Libraries/Opc.Ua.Server/RoleBasedUserManagement/RoleBasedIdentity.cs
+++ b/Libraries/Opc.Ua.Server/RoleBasedUserManagement/RoleBasedIdentity.cs
@@ -55,12 +55,6 @@ namespace Opc.Ua.Server
             new Role(ObjectIds.WellKnownRole_AuthenticatedUser, BrowseNames.WellKnownRole_AuthenticatedUser);
 
         /// <summary>
-        /// The Role is allowed to browse and read non-security related Nodes.
-        /// </summary>
-        public static Role TrustedApplication { get; } =
-            new Role(ObjectIds.WellKnownRole_TrustedApplication, BrowseNames.WellKnownRole_TrustedApplication);
-
-        /// <summary>
         /// The Role is allowed to browse, read live data, read historical data/events or subscribe to data/events.
         /// </summary>
         public static Role Observer { get; } =

--- a/Stack/Opc.Ua.Core/Stack/Client/UserIdentity.cs
+++ b/Stack/Opc.Ua.Core/Stack/Client/UserIdentity.cs
@@ -252,7 +252,7 @@ namespace Opc.Ua
         /// <summary>
         ///  Get or sets the list of granted role ids associated to the UserIdentity.
         /// </summary>
-        public ArrayOf<NodeId> GrantedRoleIds => default;
+        public ArrayOf<NodeId> GrantedRoleIds => [ObjectIds.WellKnownRole_Anonymous];
 
         /// <inheritdoc/>
         public override bool Equals(object obj)

--- a/Tests/Opc.Ua.Server.Tests/MasterNodeManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/MasterNodeManagerTests.cs
@@ -27,9 +27,11 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using Opc.Ua.Tests;
@@ -46,6 +48,168 @@ namespace Opc.Ua.Server.Tests
     [Parallelizable]
     public class MasterNodeManagerTests
     {
+        [Test]
+        public void ValidateRolePermissions_NullNodeMetadata_ReturnsGood()
+        {
+            var result = MasterNodeManager.ValidateRolePermissions(null, null, PermissionType.Read);
+            Assert.That(result.Code, Is.EqualTo(StatusCodes.Good));
+        }
+
+        [Test]
+        public void ValidateRolePermissions_PermissionNone_ReturnsGood()
+        {
+            var nodeMetadata = new NodeMetadata(null, new NodeId(1));
+            var result = MasterNodeManager.ValidateRolePermissions(null, nodeMetadata, PermissionType.None);
+            Assert.That(result.Code, Is.EqualTo(StatusCodes.Good));
+        }
+
+        [Test]
+        public void ValidateRolePermissions_NoRestrictions_ReturnsGood()
+        {
+            var nodeMetadata = new NodeMetadata(null, new NodeId(1));
+            var result = MasterNodeManager.ValidateRolePermissions(null, nodeMetadata, PermissionType.Read);
+            Assert.That(result.Code, Is.EqualTo(StatusCodes.Good));
+        }
+
+        [Test]
+        public void ValidateRolePermissions_NoGrantedRoles_ReturnsBadUserAccessDenied()
+        {
+            var identity = new Mock<IUserIdentity>();
+            identity.Setup(x => x.GrantedRoleIds).Returns(new ArrayOf<NodeId>());
+            var context = new OperationContext(new RequestHeader(), null, RequestType.Read, null, identity.Object);
+
+            var nodeMetadata = new NodeMetadata(null, new NodeId(1))
+            {
+                RolePermissions = [
+                    new RolePermissionType { RoleId = new NodeId(1), Permissions = (uint)PermissionType.Read }
+                ]
+            };
+
+            var loggerMock = new Mock<ILogger>();
+            var result = MasterNodeManager.ValidateRolePermissions(context, nodeMetadata, PermissionType.Read, loggerMock.Object);
+
+            Assert.That(result.Code, Is.EqualTo(StatusCodes.BadUserAccessDenied));
+            loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Current user has no granted role.")),
+                    It.IsAny<Exception>(),
+                    (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+                Times.Once);
+        }
+
+        [Test]
+        public void ValidateRolePermissions_DoesNotHaveRequestedPermission_ReturnsBadUserAccessDenied()
+        {
+            var identity = new Mock<IUserIdentity>();
+            identity.Setup(x => x.GrantedRoleIds).Returns([new NodeId(2)]);
+            var context = new OperationContext(new RequestHeader(), null, RequestType.Read, null, identity.Object);
+
+            var nodeMetadata = new NodeMetadata(null, new NodeId(1))
+            {
+                RolePermissions = [
+                    new RolePermissionType { RoleId = new NodeId(2), Permissions = (uint)PermissionType.Browse }
+                ]
+            };
+
+            var loggerMock = new Mock<ILogger>();
+            var result = MasterNodeManager.ValidateRolePermissions(context, nodeMetadata, PermissionType.Read, loggerMock.Object);
+
+            Assert.That(result.Code, Is.EqualTo(StatusCodes.BadUserAccessDenied));
+            loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Role permissions validation failed for node")),
+                    It.IsAny<Exception>(),
+                    (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+                Times.Once);
+        }
+
+        [Test]
+        public void ValidateRolePermissions_HasRequestedPermission_ReturnsGood()
+        {
+            var identity = new Mock<IUserIdentity>();
+            identity.Setup(x => x.GrantedRoleIds).Returns([new NodeId(2)]);
+            var context = new OperationContext(new RequestHeader(), null, RequestType.Read, null, identity.Object);
+
+            var nodeMetadata = new NodeMetadata(null, new NodeId(1))
+            {
+                RolePermissions = [
+                    new RolePermissionType { RoleId = new NodeId(2), Permissions = (uint)PermissionType.Read }
+                ]
+            };
+
+            var loggerMock = new Mock<ILogger>();
+            var result = MasterNodeManager.ValidateRolePermissions(context, nodeMetadata, PermissionType.Read, loggerMock.Object);
+
+            Assert.That(result.Code, Is.EqualTo(StatusCodes.Good));
+        }
+
+        [Test]
+        public void ValidateRolePermissions_DefaultPermissions_ReturnsGood()
+        {
+            var identity = new Mock<IUserIdentity>();
+            identity.Setup(x => x.GrantedRoleIds).Returns([new NodeId(2)]);
+            var context = new OperationContext(new RequestHeader(), null, RequestType.Read, null, identity.Object);
+
+            var nodeMetadata = new NodeMetadata(null, new NodeId(1))
+            {
+                DefaultRolePermissions = [
+                    new RolePermissionType { RoleId = new NodeId(2), Permissions = (uint)PermissionType.Read }
+                ]
+            };
+
+            var loggerMock = new Mock<ILogger>();
+            var result = MasterNodeManager.ValidateRolePermissions(context, nodeMetadata, PermissionType.Read, loggerMock.Object);
+
+            Assert.That(result.Code, Is.EqualTo(StatusCodes.Good));
+        }
+
+        [Test]
+        public void ValidateRolePermissions_DefaultUserRolePermissions_ReturnsGood()
+        {
+            var identity = new Mock<IUserIdentity>();
+            identity.Setup(x => x.GrantedRoleIds).Returns([new NodeId(2)]);
+            var context = new OperationContext(new RequestHeader(), null, RequestType.Read, null, identity.Object);
+
+            var nodeMetadata = new NodeMetadata(null, new NodeId(1))
+            {
+                DefaultUserRolePermissions = [
+                    new RolePermissionType { RoleId = new NodeId(2), Permissions = (uint)PermissionType.Read }
+                ]
+            };
+
+            var loggerMock = new Mock<ILogger>();
+            var result = MasterNodeManager.ValidateRolePermissions(context, nodeMetadata, PermissionType.Read, loggerMock.Object);
+
+            Assert.That(result.Code, Is.EqualTo(StatusCodes.Good));
+        }
+
+        [Test]
+        public void ValidateRolePermissions_UserRolePermissionsAndRolePermissionsIntersect_ReturnsGood()
+        {
+            var identity = new Mock<IUserIdentity>();
+            identity.Setup(x => x.GrantedRoleIds).Returns([new NodeId(2)]);
+            var context = new OperationContext(new RequestHeader(), null, RequestType.Read, null, identity.Object);
+
+            var nodeMetadata = new NodeMetadata(null, new NodeId(1))
+            {
+                UserRolePermissions = [
+                    new RolePermissionType { RoleId = new NodeId(2), Permissions = (uint)PermissionType.Read | (uint)PermissionType.Browse }
+                ],
+                RolePermissions = [
+                    new RolePermissionType { RoleId = new NodeId(2), Permissions = (uint)PermissionType.Read }
+                ]
+            };
+
+            var loggerMock = new Mock<ILogger>();
+            var result = MasterNodeManager.ValidateRolePermissions(context, nodeMetadata, PermissionType.Read, loggerMock.Object);
+
+            Assert.That(result.Code, Is.EqualTo(StatusCodes.Good));
+        }
+
         /// <summary>
         /// Test for registering a namespace manager for a namespace
         /// not contained in the server's namespace table


### PR DESCRIPTION
Improves role-based access control in the OPC UA server stack: fixes `ValidateRolePermissions` logic, expands default role assignments, refines `RoleBasedIdentity` merging, and adds comprehensive unit tests. Also fixes a regression that broke GDS `ApplicationSelfAdmin` sessions.

## Proposed changes

**`RoleBasedIdentity` constructor**
- Merges roles from a wrapped `RoleBasedIdentity` inner identity (avoids losing roles on re-wrap)
- Deduplicates `GrantedRoleIds` when composing from inner identity + new roles
- Removed erroneous `!role.RoleId.IsNull` filter that broke `GdsRole.ApplicationSelfAdmin`: that role uses `RoleId = ExpandedNodeId.Null` intentionally, and `OnAddSelfAdminUserRolePermissions` relies on `GrantedRoleIds.Contains(NodeId.Null)` to detect self-admin sessions

**`UserIdentity`**
- Default `GrantedRoleIds` now returns `[WellKnownRole_Anonymous]` instead of empty, preventing `ValidateRolePermissions` from failing with "no granted role" for unauthenticated sessions

**`ValidateRolePermissions` (`MasterNodeManager`)**
- Stores full permissions per role (not pre-masked by `requestedPermission`); applies the mask at match-time — logically equivalent but consistent across multi-entry roles
- Added `ILogger` parameter for access-denial diagnostics
- Fixed `PrepareValidationCache<T>` to correctly handle `BrowseDescription` and `CallMethodRequest` node IDs (previously only `ReadValueId` was handled, others threw on null nodeId)

**Role additions**
- Added `Role.TrustedApplication` and `Role.AuthenticatedUser` static properties
- `SessionManager` assigns `TrustedApplication` role when the session has a client certificate and `SecurityMode >= Sign`

**GDS fix**
- Removed `System.Data` stray `using` directive

**Tests**
- New unit tests in `Opc.Ua.Server.Tests` covering `ValidateRolePermissions` scenarios: no permissions defined, anonymous access, role match/mismatch, and logger output on denial

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [x] I ran tests locally with my changes, all passed.
- [x] I fixed all failing tests in the CI pipelines.
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The GDS regression root cause: `RoleBasedIdentity` was filtering `role.RoleId.IsNull` before converting to `NodeId`, so `ApplicationSelfAdmin` (intentionally null RoleId) never contributed `NodeId.Null` to `GrantedRoleIds`. The GDS `OnAddSelfAdminUserRolePermissions` callback uses `GrantedRoleIds.Contains(NodeId.Null)` as the signal to inject `Call` permission into `UserRolePermissions` — without it, `ValidateRolePermissions` in `CustomNodeManager.CallInternalAsync` returned `BadUserAccessDenied` before the method handler was reached.