### PR TITLE
Add structure-backed OptionSet DataType support in ComplexTypeSystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ DocProject/Help/html
 
 # Click-Once directory
 publish/
+publish-aot/
 
 # Publish Web Output
 *.[Pp]ublish.xml

--- a/Applications/ConsoleReferenceClient/ClientSamples.cs
+++ b/Applications/ConsoleReferenceClient/ClientSamples.cs
@@ -31,7 +31,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -1109,7 +1108,7 @@ namespace Quickstarts
             var stopWatch = new Stopwatch();
             stopWatch.Start();
 
-            await complexTypeSystem.LoadAsync(throwOnError: true, ct: ct).ConfigureAwait(false);
+            bool loaded = await complexTypeSystem.LoadAsync(throwOnError: true, ct: ct).ConfigureAwait(false);
 
             stopWatch.Stop();
 
@@ -1117,6 +1116,13 @@ namespace Quickstarts
                 "Loaded {Count} types took {Duration}ms.",
                 complexTypeSystem.GetDefinedTypes().Count,
                 stopWatch.ElapsedMilliseconds);
+
+            if (!loaded)
+            {
+                throw new ServiceResultException(
+                    StatusCodes.BadTypeMismatch,
+                    "ComplexTypeSystem.LoadAsync did not load all custom types.");
+            }
 
             if (m_verbose)
             {
@@ -1566,10 +1572,6 @@ namespace Quickstarts
         /// <param name="session">The session to use for exporting.</param>
         /// <param name="nodes">The list of nodes to export.</param>
         /// <param name="filePath">The path where the NodeSet2 XML file will be saved.</param>
-        [RequiresUnreferencedCode(
-            "Uses XmlSerializer which requires unreferenced code.")]
-        [RequiresDynamicCode(
-            "Uses XmlSerializer which requires unreferenced code.")]
         public void ExportNodesToNodeSet2(ISession session, IList<INode> nodes, string filePath)
         {
             m_logger.LogInformation("Exporting {Count} nodes to {FilePath}...", nodes.Count, filePath);
@@ -1606,10 +1608,6 @@ namespace Quickstarts
         /// <returns>A dictionary mapping namespace URI to the file path of the exported NodeSet2 file.</returns>
         /// <exception cref="ArgumentNullException">Thrown when session, nodes, or outputDirectory is null.</exception>
         /// <exception cref="ArgumentException">Thrown when outputDirectory is empty or whitespace.</exception>
-        [RequiresUnreferencedCode(
-            "Uses XmlSerializer which requires unreferenced code.")]
-        [RequiresDynamicCode(
-            "Uses XmlSerializer which requires unreferenced code.")]
         public async Task<IReadOnlyDictionary<string, string>> ExportNodesToNodeSet2PerNamespaceAsync(
             ISession session,
             IList<INode> nodes,

--- a/Applications/ConsoleReferenceClient/ConsoleReferenceClient.csproj
+++ b/Applications/ConsoleReferenceClient/ConsoleReferenceClient.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Extensions.Logging" />
-    <PackageReference Include="Serilog.Expressions" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="Serilog.Sinks.Debug" />

--- a/Applications/ConsoleReferenceClient/Program.cs
+++ b/Applications/ConsoleReferenceClient/Program.cs
@@ -526,8 +526,11 @@ namespace Quickstarts.ConsoleReferenceClient
 
                                     if (exportNodes)
                                     {
-                                        await samples
-                                            .ExportNodesToNodeSet2PerNamespaceAsync(uaClient.Session, allNodes, Environment.CurrentDirectory, cancellationToken)
+                                        await samples.ExportNodesToNodeSet2PerNamespaceAsync(
+                                                uaClient.Session,
+                                                allNodes,
+                                                Environment.CurrentDirectory,
+                                                cancellationToken)
                                             .ConfigureAwait(false);
                                     }
                                 }

--- a/Applications/ConsoleReferencePublisher/ConsoleReferencePublisher.csproj
+++ b/Applications/ConsoleReferencePublisher/ConsoleReferencePublisher.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="System.Private.Uri" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Extensions.Logging" />
-    <PackageReference Include="Serilog.Expressions" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="Serilog.Sinks.Debug" />

--- a/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
+++ b/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
@@ -29,7 +29,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Serilog" />
-    <PackageReference Include="Serilog.Expressions" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Extensions.Logging" />
     <PackageReference Include="Serilog.Sinks.File" />

--- a/Applications/ConsoleReferenceServer/ConsoleUtils.cs
+++ b/Applications/ConsoleReferenceServer/ConsoleUtils.cs
@@ -40,7 +40,6 @@ using System.CommandLine.Help;
 using Opc.Ua;
 using Serilog;
 using Serilog.Events;
-using Serilog.Templates;
 #if NET5_0_OR_GREATER
 using Microsoft.Extensions.Configuration;
 #endif
@@ -176,9 +175,8 @@ namespace Quickstarts
                 if (!string.IsNullOrWhiteSpace(outputFilePath))
                 {
                     loggerConfiguration.WriteTo.File(
-                        new ExpressionTemplate(
-                            "{UtcDateTime(@t):yyyy-MM-dd HH:mm:ss.fff} [{@l:u3}] {@m}\n{@x}"),
                         Utils.ReplaceSpecialFolderNames(outputFilePath),
+                        outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {Message:lj}{NewLine}{Exception}",
                         restrictedToMinimumLevel: (LogEventLevel)fileLevel,
                         rollOnFileSizeLimit: true
                     );

--- a/Applications/ConsoleReferenceSubscriber/ConsoleReferenceSubscriber.csproj
+++ b/Applications/ConsoleReferenceSubscriber/ConsoleReferenceSubscriber.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="System.Private.Uri" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Extensions.Logging" />
-    <PackageReference Include="Serilog.Expressions" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="Serilog.Sinks.Debug" />

--- a/Docs/ComplexTypes.md
+++ b/Docs/ComplexTypes.md
@@ -837,7 +837,9 @@ TypeInfo TypeInfo { get; }                // Type info of the field
 
 ## Known Limitations
 
-1. **OptionSet Support**: OPC UA 1.04 OptionSet types do not automatically create enumeration flags
+1. **OptionSet Support**: Concrete Structure-backed sub-types of the abstract `OptionSet` DataType (`i=12755`, e.g. `AccessRights`, `CarExtras`) are automatically registered by the default `ComplexTypeSystem` builder as `Opc.Ua.Encoders.OptionSet` runtime instances, driven by either the `EnumDefinition` carried in `DataTypeDefinition` or a fallback synthesized from the `OptionSetValues` property. The runtime class exposes the two canonical `Value` / `ValidBits` ByteStrings plus bit accessors keyed by field name or bit index. Per Part 3 §8.40 / §3.2.8, the overall ByteString length is fixed by the sub-type's declared bits (exposed as `ByteLength`); setting a bit outside that range throws `ArgumentOutOfRangeException`. Remaining limitations:
+   - UInteger-backed OptionSet DataTypes (DataTypes deriving from an unsigned integer with `IsOptionSet=true`) continue to be represented as their underlying unsigned integer in a `Variant` — no per-bit metadata is surfaced.
+   - The legacy Reflection.Emit builder in `Opc.Ua.Client.ComplexTypes` throws `NotSupportedException` for OptionSet sub-types; switch to the default builder (`new ComplexTypeSystem(session)`) for OptionSet support.
 2. **Legacy Dictionary Support**: Some OPC UA 1.03 structured types that cannot be mapped to OPC UA 1.04 definitions are ignored
 3. **Type Modifications**: Once loaded, types cannot be dynamically updated during a session. Reconnect to reload modified types.
 

--- a/Docs/MigrationGuide.md
+++ b/Docs/MigrationGuide.md
@@ -43,6 +43,7 @@
       - [ExtensionObject array helpers changed](#extensionobject-array-helpers-changed)
     - [Complex Types](#complex-types)
       - [ComplexTypes moved to Opc.Ua.Client assembly](#complextypes-moved-to-opcuaclient-assembly)
+      - [OptionSet DataType support](#optionset-datatype-support)
     - [Other Breaking Changes](#other-breaking-changes)
   - [Migrating from 1.05.377 to 1.05.378](#migrating-from-105377-to-105378)
     - [Asynchronous as default](#asynchronous-as-default)
@@ -615,6 +616,17 @@ The `[Obsolete]` static `EncodeableFactory.GlobalFactory` was removed. `Encodeab
 Core complex type interfaces and default (non-reflection-emit) implementations moved from `Opc.Ua.Client.ComplexTypes` to `Libraries/Opc.Ua.Client/ComplexTypes/`.
 Namespace remains `Opc.Ua.Client.ComplexTypes`. If you used the default constructors without specifying the builder, and want to use the Reflection.Emit based type builders,
 you need to change your code to call `ComplexTypeSystem.Create(...)` instead of `new ComplexTypeSystem(...)` which now uses the new default builder not supporting Reflection.Emit.
+
+#### OptionSet DataType support
+
+Concrete Structure-backed sub-types of the abstract `OptionSet` DataType (`i=12755`) are now automatically registered by the default `ComplexTypeSystem` builder with a new runtime class `Opc.Ua.Encoders.OptionSet` (in `Stack/Opc.Ua.Types`). Bit-field metadata is resolved from `DataTypeDefinition` (`EnumDefinition`) or, as a fallback, synthesized from the `OptionSetValues` property (`LocalizedText[]`).
+
+Impact on existing code:
+
+- **Source-breaking for custom `IComplexTypeBuilder` implementations**: a new member `AddOptionSetType(QualifiedName, ExpandedNodeId, ExpandedNodeId, ExpandedNodeId, ExpandedNodeId, EnumDefinition)` was added to `IComplexTypeBuilder`. Custom implementations must provide it.
+- The Reflection.Emit builder in `Opc.Ua.Client.ComplexTypes` throws `NotSupportedException` from `AddOptionSetType`; callers relying on the Reflection.Emit path for OptionSet sub-types should switch to the default builder (`new ComplexTypeSystem(session)`).
+- No wire-format changes: encoders/decoders continue to route through `IEncodeableFactory` → `IEncodeableType.CreateInstance`, which now yields `Opc.Ua.Encoders.OptionSet` for registered sub-types.
+- UInteger-backed OptionSet DataTypes remain treated as their underlying unsigned integer in a `Variant` (unchanged).
 
 ### Other Breaking Changes
 

--- a/Libraries/Opc.Ua.Client.ComplexTypes/TypeBuilder/ComplexTypeBuilder.cs
+++ b/Libraries/Opc.Ua.Client.ComplexTypes/TypeBuilder/ComplexTypeBuilder.cs
@@ -150,6 +150,25 @@ namespace Opc.Ua.Client.ComplexTypes
         }
 
         /// <summary>
+        /// OptionSet sub-types are not supported by the Reflection.Emit
+        /// complex type builder. Use the default (source-generated)
+        /// complex type builder instead for OptionSet support.
+        /// </summary>
+        /// <exception cref="NotSupportedException">Always thrown.</exception>
+        public IEncodeableType AddOptionSetType(
+            QualifiedName typeName,
+            ExpandedNodeId typeId,
+            ExpandedNodeId binaryEncodingId,
+            ExpandedNodeId xmlEncodingId,
+            ExpandedNodeId jsonEncodingId,
+            EnumDefinition enumDefinition)
+        {
+            throw new NotSupportedException(
+                "OptionSet DataTypes are not supported by the Reflection.Emit " +
+                "complex type builder. Use the default complex type builder.");
+        }
+
+        /// <summary>
         /// Create a unique namespace module name for the type.
         /// </summary>
         private static string FindModuleName(string moduleName, string targetNamespace)

--- a/Libraries/Opc.Ua.Client/ComplexTypes/ComplexTypeSystem.cs
+++ b/Libraries/Opc.Ua.Client/ComplexTypes/ComplexTypeSystem.cs
@@ -49,7 +49,9 @@ namespace Opc.Ua.Client.ComplexTypes
     /// with the following known restrictions:
     /// - Support only for V1.03 structured types which can be mapped to the V1.04
     /// structured type definition. Unsupported V1.03 types are ignored.
-    /// - V1.04 OptionSet does not create the enumeration flags.
+    /// - Concrete Structure-backed sub-types of the abstract <c>OptionSet</c>
+    /// DataType are supported. UInteger-backed <c>IsOptionSet</c> DataTypes
+    /// are left opaque (their wire form is the plain unsigned integer).
     /// </remarks>
     public class ComplexTypeSystem
     {
@@ -987,10 +989,65 @@ namespace Opc.Ua.Client.ComplexTypes
 
                             if (newType == null)
                             {
-                                structTypesToDoList.Add(structType);
                                 if (structureDefinition != null)
                                 {
+                                    structTypesToDoList.Add(structType);
                                     retryAddStructType = true;
+                                }
+                                else if (await IsOptionSetSubtypeAsync(structType.NodeId, ct)
+                                    .ConfigureAwait(false))
+                                {
+                                    // Concrete Structure-backed sub-type of the
+                                    // abstract OptionSet DataType. The wire
+                                    // format is the inherited Value/ValidBits
+                                    // ByteStrings; field semantics come from an
+                                    // EnumDefinition or the OptionSetValues
+                                    // property.
+                                    (
+                                        ArrayOf<NodeId> encodingIds,
+                                        ExpandedNodeId binaryEncodingId,
+                                        ExpandedNodeId xmlEncodingId
+                                    ) = await m_complexTypeResolver
+                                        .BrowseForEncodingsAsync(
+                                            structType.NodeId,
+                                            s_supportedEncodings,
+                                            ct)
+                                        .ConfigureAwait(false);
+                                    ExpandedNodeId typeId = NormalizeExpandedNodeId(
+                                        structType.NodeId);
+                                    newType = await AddOptionSetTypeAsync(
+                                            complexTypeBuilder,
+                                            dataTypeNode,
+                                            typeId,
+                                            binaryEncodingId,
+                                            xmlEncodingId,
+                                            ExpandedNodeId.Null,
+                                            ct)
+                                        .ConfigureAwait(false);
+                                    if (newType != null)
+                                    {
+                                        foreach (NodeId encodingId in encodingIds)
+                                        {
+                                            AddEncodeableType(encodingId, newType);
+                                        }
+                                        AddEncodeableType(structType.NodeId, newType);
+                                    }
+                                    else
+                                    {
+                                        m_logger.LogInformation(
+                                            "Skipped OptionSet sub-type {DataType} because no EnumDefinition or OptionSetValues property was found.",
+                                            dataTypeNode.BrowseName.Name);
+                                    }
+                                }
+                                else
+                                {
+                                    // A non-abstract Structure subtype without a valid
+                                    // DataTypeDefinition cannot be materialized by this path.
+                                    // Skip silently so the overall load is not marked as failed
+                                    // when the server exposes such unresolvable types.
+                                    m_logger.LogInformation(
+                                        "Skipped the type definition of {DataType} because no DataTypeDefinition is available.",
+                                        dataTypeNode.BrowseName.Name);
                                 }
                             }
                         }
@@ -1288,6 +1345,91 @@ namespace Opc.Ua.Client.ComplexTypes
                 }
             }
             return newType;
+        }
+
+        /// <summary>
+        /// Add an OptionSet type defined in a DataType node whose wire
+        /// format is the inherited <c>Value</c>/<c>ValidBits</c>
+        /// ByteStrings of the abstract <c>OptionSet</c> DataType.
+        /// </summary>
+        private async Task<IEncodeableType?> AddOptionSetTypeAsync(
+            IComplexTypeBuilder complexTypeBuilder,
+            DataTypeNode dataTypeNode,
+            ExpandedNodeId typeId,
+            ExpandedNodeId binaryEncodingId,
+            ExpandedNodeId xmlEncodingId,
+            ExpandedNodeId jsonEncodingId,
+            CancellationToken ct = default)
+        {
+            QualifiedName name = dataTypeNode.BrowseName;
+
+            // 1. use DataTypeDefinition
+            if (DisableDataTypeDefinition ||
+                !dataTypeNode.DataTypeDefinition.TryGetEncodeable(
+                    out EnumDefinition? enumDefinition))
+            {
+                // 2. fall back to OptionSetValues property (LocalizedText[])
+                Variant enumTypeArray = await m_complexTypeResolver
+                    .GetEnumTypeArrayAsync(dataTypeNode.NodeId, ct)
+                    .ConfigureAwait(false);
+                if (enumTypeArray.TryGet(out ArrayOf<LocalizedText> localizedText))
+                {
+                    enumDefinition = localizedText.ToEnumDefinition(name.Name);
+                }
+                else
+                {
+                    enumDefinition = null;
+                }
+            }
+
+            if (enumDefinition == null)
+            {
+                return null;
+            }
+
+            // Mark as OptionSet (bit positions rather than ordinal values).
+            enumDefinition.IsOptionSet = true;
+
+            // Add EnumDefinition to cache
+            m_dataTypeDefinitionCache[dataTypeNode.NodeId] = enumDefinition;
+
+            return complexTypeBuilder.AddOptionSetType(
+                name,
+                typeId,
+                binaryEncodingId,
+                xmlEncodingId,
+                jsonEncodingId,
+                enumDefinition);
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> if <paramref name="dataTypeId"/> is a
+        /// concrete sub-type of the abstract <c>OptionSet</c> DataType.
+        /// </summary>
+        private async Task<bool> IsOptionSetSubtypeAsync(
+            ExpandedNodeId dataTypeId,
+            CancellationToken ct)
+        {
+            NodeId superType = ExpandedNodeId.ToNodeId(
+                dataTypeId,
+                m_complexTypeResolver.NamespaceUris);
+            while (!superType.IsNull)
+            {
+                superType = await m_complexTypeResolver
+                    .FindSuperTypeAsync(superType, ct)
+                    .ConfigureAwait(false);
+                if (superType == DataTypeIds.OptionSet)
+                {
+                    return true;
+                }
+                if (superType == DataTypeIds.Structure ||
+                    superType == DataTypeIds.Enumeration ||
+                    TypeInfo.GetBuiltInType(superType) != BuiltInType.Null)
+                {
+                    return false;
+                }
+            }
+            return false;
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Client/ComplexTypes/DefaultComplexTypeBuilder.cs
+++ b/Libraries/Opc.Ua.Client/ComplexTypes/DefaultComplexTypeBuilder.cs
@@ -74,6 +74,27 @@ namespace Opc.Ua.Client.ComplexTypes
             return new DefaultComplexTypeFieldBuilder(this, name, structureDefinition);
         }
 
+        /// <inheritdoc/>
+        public IEncodeableType AddOptionSetType(
+            QualifiedName typeName,
+            ExpandedNodeId typeId,
+            ExpandedNodeId binaryEncodingId,
+            ExpandedNodeId xmlEncodingId,
+            ExpandedNodeId jsonEncodingId,
+            EnumDefinition enumDefinition)
+        {
+            var xmlName = new XmlQualifiedName(typeName.Name, TargetNamespace);
+            var type = new Encoders.OptionSet(
+                xmlName,
+                typeId,
+                binaryEncodingId,
+                xmlEncodingId,
+                jsonEncodingId,
+                enumDefinition);
+            OnTypeCreated(type);
+            return type;
+        }
+
         /// <summary>
         /// Type created
         /// </summary>

--- a/Libraries/Opc.Ua.Client/ComplexTypes/IComplexTypeFactory.cs
+++ b/Libraries/Opc.Ua.Client/ComplexTypes/IComplexTypeFactory.cs
@@ -81,6 +81,22 @@ namespace Opc.Ua.Client.ComplexTypes
         IComplexTypeFieldBuilder AddStructuredType(
             QualifiedName name,
             StructureDefinition structureDefinition);
+
+        /// <summary>
+        /// Create an OptionSet type for a concrete sub-type of the
+        /// abstract <c>OptionSet</c> DataType. The wire format is the
+        /// inherited <c>Value</c>/<c>ValidBits</c> ByteStrings; the
+        /// <paramref name="enumDefinition"/> names the bits and is
+        /// either obtained from the DataTypeDefinition attribute or
+        /// synthesized from the <c>OptionSetValues</c> property.
+        /// </summary>
+        IEncodeableType AddOptionSetType(
+            QualifiedName typeName,
+            ExpandedNodeId typeId,
+            ExpandedNodeId binaryEncodingId,
+            ExpandedNodeId xmlEncodingId,
+            ExpandedNodeId jsonEncodingId,
+            EnumDefinition enumDefinition);
     }
 
     /// <summary>

--- a/Stack/Opc.Ua/Types/OptionSet.cs
+++ b/Stack/Opc.Ua/Types/OptionSet.cs
@@ -1,0 +1,327 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml;
+
+namespace Opc.Ua.Encoders
+{
+    /// <summary>
+    /// Runtime representation of a concrete Structure-backed
+    /// sub-type of the abstract <see cref="Opc.Ua.OptionSet"/>
+    /// DataType whose field semantics are described by an
+    /// <see cref="EnumDefinition"/>.
+    /// </summary>
+    /// <remarks>
+    /// The wire format (<c>Value</c> / <c>ValidBits</c>
+    /// <see cref="ByteString"/>s) is inherited from the generated
+    /// <see cref="Opc.Ua.OptionSet"/> base class. This class carries
+    /// the concrete sub-type's TypeId / encoding ids and the
+    /// bit-field metadata, and self-registers with
+    /// <see cref="IEncodeableFactory"/> via
+    /// <see cref="IEncodeableType"/>.
+    /// </remarks>
+    public sealed class OptionSet :
+        global::Opc.Ua.OptionSet,
+        IEncodeableType
+    {
+        /// <summary>
+        /// Create a new OptionSet runtime type.
+        /// </summary>
+        public OptionSet(
+            XmlQualifiedName xmlName,
+            ExpandedNodeId typeId,
+            ExpandedNodeId binaryEncodingId,
+            ExpandedNodeId xmlEncodingId,
+            ExpandedNodeId jsonEncodingId,
+            EnumDefinition enumDefinition)
+        {
+            XmlName = xmlName ?? throw new ArgumentNullException(nameof(xmlName));
+            Definition = enumDefinition ?? throw new ArgumentNullException(nameof(enumDefinition));
+            m_typeId = typeId;
+            m_binaryEncodingId = binaryEncodingId;
+            m_xmlEncodingId = xmlEncodingId;
+            m_jsonEncodingId = jsonEncodingId;
+            m_byteLength = ComputeByteLength(enumDefinition);
+        }
+
+        private OptionSet(OptionSet source, bool copyValues)
+        {
+            XmlName = source.XmlName;
+            Definition = source.Definition;
+            m_typeId = source.m_typeId;
+            m_binaryEncodingId = source.m_binaryEncodingId;
+            m_xmlEncodingId = source.m_xmlEncodingId;
+            m_jsonEncodingId = source.m_jsonEncodingId;
+            m_byteLength = source.m_byteLength;
+            if (copyValues)
+            {
+                Value = source.Value.Copy();
+                ValidBits = source.ValidBits.Copy();
+            }
+        }
+
+        /// <inheritdoc/>
+        public Type Type => typeof(OptionSet);
+
+        /// <inheritdoc/>
+        public XmlQualifiedName XmlName { get; }
+
+        /// <summary>
+        /// The bit-field definition of this concrete OptionSet sub-type.
+        /// Each <see cref="EnumField"/>'s Value is the bit index (0-based).
+        /// </summary>
+        public EnumDefinition Definition { get; }
+
+        /// <summary>
+        /// The fixed byte length of the <see cref="Opc.Ua.OptionSet.Value"/>
+        /// and <see cref="Opc.Ua.OptionSet.ValidBits"/> ByteStrings for this
+        /// OptionSet sub-type, derived from the highest bit index declared
+        /// in <see cref="Definition"/>.
+        /// </summary>
+        /// <remarks>
+        /// Per OPC UA Part 3 §8.40 / §3.2.8: OptionSet sub-types may add new
+        /// Bits but must not change the overall length of the underlying
+        /// ByteStrings. This value is therefore fixed at construction; bits
+        /// outside the range <c>[0, ByteLength*8)</c> cannot be set.
+        /// </remarks>
+        public int ByteLength => m_byteLength;
+
+        /// <inheritdoc/>
+        public override ExpandedNodeId TypeId => m_typeId;
+
+        /// <inheritdoc/>
+        public override ExpandedNodeId BinaryEncodingId => m_binaryEncodingId;
+
+        /// <inheritdoc/>
+        public override ExpandedNodeId XmlEncodingId => m_xmlEncodingId;
+
+        /// <inheritdoc/>
+        public override ExpandedNodeId JsonEncodingId => m_jsonEncodingId;
+
+        /// <inheritdoc/>
+        public IEncodeable CreateInstance()
+        {
+            return new OptionSet(this, copyValues: false);
+        }
+
+        /// <inheritdoc/>
+        public override object Clone()
+        {
+            return new OptionSet(this, copyValues: true);
+        }
+
+        /// <summary>
+        /// Gets or sets the bit corresponding to the given field name
+        /// (as declared in <see cref="Definition"/>).
+        /// </summary>
+        public bool this[string fieldName]
+        {
+            get
+            {
+                if (!TryGetBitIndex(fieldName, out int bit))
+                {
+                    throw new ArgumentException(
+                        CoreUtils.Format("Unknown OptionSet field '{0}'.", fieldName),
+                        nameof(fieldName));
+                }
+                return GetBit(Value.Span, bit);
+            }
+            set
+            {
+                if (!TryGetBitIndex(fieldName, out int bit))
+                {
+                    throw new ArgumentException(
+                        CoreUtils.Format("Unknown OptionSet field '{0}'.", fieldName),
+                        nameof(fieldName));
+                }
+                SetBit(bit, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the bit at the specified bit index.
+        /// </summary>
+        public bool this[int bit]
+        {
+            get => GetBit(Value.Span, bit);
+            set => SetBit(bit, value);
+        }
+
+        /// <summary>
+        /// Returns the names of all bits that are set and marked
+        /// valid according to <see cref="Opc.Ua.OptionSet.ValidBits"/>.
+        /// If <see cref="Opc.Ua.OptionSet.ValidBits"/> is empty the
+        /// OptionSet is treated as fully valid.
+        /// </summary>
+        public IReadOnlyList<string> GetSetFieldNames()
+        {
+            var names = new List<string>();
+            if (Definition.Fields.IsEmpty)
+            {
+                return names;
+            }
+            ReadOnlySpan<byte> value = Value.Span;
+            ReadOnlySpan<byte> valid = ValidBits.Span;
+            bool validOmitted = valid.IsEmpty;
+            foreach (EnumField field in Definition.Fields)
+            {
+                int bit = (int)field.Value;
+                if (bit < 0)
+                {
+                    continue;
+                }
+                if (GetBit(value, bit) && (validOmitted || GetBit(valid, bit)))
+                {
+                    names.Add(field.Name);
+                }
+            }
+            return names;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            var sb = new StringBuilder(XmlName?.Name ?? "OptionSet").Append(" {");
+            bool first = true;
+            foreach (string name in GetSetFieldNames())
+            {
+                if (!first)
+                {
+                    sb.Append(", ");
+                }
+                sb.Append(name);
+                first = false;
+            }
+            return sb.Append('}').ToString();
+        }
+
+        private bool TryGetBitIndex(string fieldName, out int bit)
+        {
+            if (!string.IsNullOrEmpty(fieldName) && !Definition.Fields.IsEmpty)
+            {
+                foreach (EnumField field in Definition.Fields)
+                {
+                    if (field.Name == fieldName)
+                    {
+                        bit = (int)field.Value;
+                        return bit >= 0;
+                    }
+                }
+            }
+            bit = -1;
+            return false;
+        }
+
+        private static bool GetBit(ReadOnlySpan<byte> bytes, int bit)
+        {
+            if (bit < 0)
+            {
+                return false;
+            }
+            int byteIndex = bit >> 3;
+            if ((uint)byteIndex >= (uint)bytes.Length)
+            {
+                return false;
+            }
+            return (bytes[byteIndex] & (1 << (bit & 7))) != 0;
+        }
+
+        private void SetBit(int bit, bool on)
+        {
+            if (bit < 0 || bit >= m_byteLength * 8)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(bit),
+                    CoreUtils.Format(
+                        "Bit index {0} is outside the fixed {1}-byte OptionSet length. "
+                        + "OPC UA Part 3 §8.40 requires that sub-types do not change the overall length.",
+                        bit,
+                        m_byteLength));
+            }
+            int byteIndex = bit >> 3;
+            int mask = 1 << (bit & 7);
+
+            Value = WithBit(Value, byteIndex, mask, on, m_byteLength);
+            // Setting a bit implicitly marks the bit valid.
+            ValidBits = WithBit(ValidBits, byteIndex, mask, true, m_byteLength);
+        }
+
+        private static ByteString WithBit(ByteString source, int byteIndex, int mask, bool on, int fixedLength)
+        {
+            byte[] buffer = new byte[fixedLength];
+            if (!source.IsEmpty)
+            {
+                int copyLength = Math.Min(source.Length, fixedLength);
+                source.Span.Slice(0, copyLength).CopyTo(buffer);
+            }
+            if (on)
+            {
+                buffer[byteIndex] = (byte)(buffer[byteIndex] | mask);
+            }
+            else
+            {
+                buffer[byteIndex] = (byte)(buffer[byteIndex] & ~mask);
+            }
+            return ByteString.From(buffer);
+        }
+
+        private static int ComputeByteLength(EnumDefinition definition)
+        {
+            if (definition.Fields.IsEmpty)
+            {
+                return 0;
+            }
+            long maxBit = -1;
+            foreach (EnumField field in definition.Fields)
+            {
+                if (field.Value > maxBit)
+                {
+                    maxBit = field.Value;
+                }
+            }
+            if (maxBit < 0)
+            {
+                return 0;
+            }
+            return (int)((maxBit >> 3) + 1);
+        }
+
+        private readonly int m_byteLength;
+
+        private readonly ExpandedNodeId m_typeId;
+        private readonly ExpandedNodeId m_binaryEncodingId;
+        private readonly ExpandedNodeId m_xmlEncodingId;
+        private readonly ExpandedNodeId m_jsonEncodingId;
+    }
+}

--- a/Tests/Opc.Ua.Client.Tests/ComplexTypes/DefaultOptionSetTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/ComplexTypes/DefaultOptionSetTests.cs
@@ -1,0 +1,365 @@
+/* ========================================================================
+ * Copyright (c) 2005-2025 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using System.IO;
+using System.Xml;
+using NUnit.Framework;
+using Opc.Ua.Client.ComplexTypes;
+using Opc.Ua.Tests;
+
+using OptionSetEncoder = Opc.Ua.Encoders.OptionSet;
+
+namespace Opc.Ua.Client.Tests.ComplexTypes
+{
+    /// <summary>
+    /// Tests for the OptionSet type created by DefaultComplexTypeBuilder.
+    /// </summary>
+    [TestFixture]
+    [Category("DefaultComplexTypes")]
+    [SetCulture("en-us")]
+    [SetUICulture("en-us")]
+    [Parallelizable]
+    public class DefaultOptionSetTests
+    {
+        private const ushort kNamespaceIndex = 3;
+        private const string kTypeNamespace = Namespaces.OpcUaEncoderTests;
+        private static readonly ExpandedNodeId s_typeId =
+            new(1001u, kTypeNamespace);
+        private static readonly ExpandedNodeId s_binaryId =
+            new(1002u, kTypeNamespace);
+        private static readonly ExpandedNodeId s_xmlId =
+            new(1003u, kTypeNamespace);
+
+        private DefaultComplexTypeFactory m_factory;
+        private IComplexTypeBuilder m_builder;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            m_factory = new DefaultComplexTypeFactory();
+            m_builder = m_factory.Create(
+                kTypeNamespace,
+                kNamespaceIndex,
+                "OptionSetTests");
+        }
+
+        private static EnumDefinition CreateAccessRightsDefinition()
+        {
+            return new EnumDefinition
+            {
+                IsOptionSet = true,
+                Fields =
+                [
+                    new EnumField { Name = "CurrentRead", Value = 0 },
+                    new EnumField { Name = "CurrentWrite", Value = 1 },
+                    new EnumField { Name = "HistoryRead", Value = 2 },
+                    new EnumField { Name = "HistoryWrite", Value = 3 }
+                ]
+            };
+        }
+
+        [Test]
+        public void AddOptionSetTypeReturnsRegisterableType()
+        {
+            EnumDefinition definition = CreateAccessRightsDefinition();
+
+            IEncodeableType encodeableType = m_builder.AddOptionSetType(
+                QualifiedName.From("AccessRights"),
+                s_typeId,
+                s_binaryId,
+                s_xmlId,
+                ExpandedNodeId.Null,
+                definition);
+
+            Assert.That(encodeableType, Is.Not.Null);
+            Assert.That(encodeableType.Type, Is.EqualTo(typeof(OptionSetEncoder)));
+            Assert.That(
+                encodeableType.XmlName,
+                Is.EqualTo(new XmlQualifiedName("AccessRights", kTypeNamespace)));
+
+            IEncodeable instance = encodeableType.CreateInstance();
+            Assert.That(instance, Is.InstanceOf<OptionSetEncoder>());
+            var optionSet = (OptionSetEncoder)instance;
+            Assert.That(optionSet.TypeId, Is.EqualTo(s_typeId));
+            Assert.That(optionSet.BinaryEncodingId, Is.EqualTo(s_binaryId));
+            Assert.That(optionSet.XmlEncodingId, Is.EqualTo(s_xmlId));
+            Assert.That(optionSet.Definition, Is.SameAs(definition));
+            Assert.That(optionSet.Value.IsEmpty, Is.True);
+            Assert.That(optionSet.ValidBits.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void BitAccessorsByNameSetValueAndValidBits()
+        {
+            EnumDefinition definition = CreateAccessRightsDefinition();
+            var optionSet = new OptionSetEncoder(
+                new XmlQualifiedName("AccessRights", kTypeNamespace),
+                s_typeId, s_binaryId, s_xmlId, ExpandedNodeId.Null,
+                definition);
+
+            optionSet["CurrentRead"] = true;
+            optionSet["HistoryWrite"] = true;
+
+            Assert.That(optionSet["CurrentRead"], Is.True);
+            Assert.That(optionSet["CurrentWrite"], Is.False);
+            Assert.That(optionSet["HistoryRead"], Is.False);
+            Assert.That(optionSet["HistoryWrite"], Is.True);
+
+            // Value bits 0 and 3 set => 0b1001 = 0x09
+            Assert.That(optionSet.Value.Span.ToArray(), Is.EqualTo(new byte[] { 0x09 }));
+            // ValidBits mirror any Set bit
+            Assert.That(optionSet.ValidBits.Span.ToArray(), Is.EqualTo(new byte[] { 0x09 }));
+
+            Assert.That(
+                optionSet.GetSetFieldNames(),
+                Is.EqualTo(new[] { "CurrentRead", "HistoryWrite" }));
+        }
+
+        [Test]
+        public void BitAccessorByIndexOutsideValueIsFalse()
+        {
+            EnumDefinition definition = CreateAccessRightsDefinition();
+            var optionSet = new OptionSetEncoder(
+                new XmlQualifiedName("AccessRights", kTypeNamespace),
+                s_typeId, s_binaryId, s_xmlId, ExpandedNodeId.Null,
+                definition);
+
+            Assert.That(optionSet[0], Is.False);
+            Assert.That(optionSet[63], Is.False);
+        }
+
+        [Test]
+        public void BinaryRoundTripPreservesValueAndValidBits()
+        {
+            EnumDefinition definition = CreateAccessRightsDefinition();
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            IServiceMessageContext context = ServiceMessageContext.Create(telemetry);
+            context.NamespaceUris.GetIndexOrAppend(kTypeNamespace);
+
+            // Register the type for decode via the factory.
+            IEncodeableType type = m_builder.AddOptionSetType(
+                QualifiedName.From("AccessRights"),
+                s_typeId, s_binaryId, s_xmlId, ExpandedNodeId.Null,
+                definition);
+            context.Factory.Builder
+                .AddEncodeableType(s_binaryId, type)
+                .AddEncodeableType(s_typeId, type)
+                .AddEncodeableType(type)
+                .Commit();
+
+            var source = (OptionSetEncoder)type.CreateInstance();
+            source["CurrentWrite"] = true;
+            source["HistoryRead"] = true;
+
+            byte[] buffer;
+            using (var stream = new MemoryStream())
+            using (var encoder = new BinaryEncoder(stream, context, false))
+            {
+                encoder.WriteExtensionObject("os", new ExtensionObject(source, true));
+                buffer = stream.ToArray();
+            }
+
+            OptionSetEncoder decoded;
+            using (var stream = new MemoryStream(buffer))
+            using (var decoder = new BinaryDecoder(stream, context))
+            {
+                ExtensionObject eo = decoder.ReadExtensionObject("os");
+                Assert.That(eo.IsNull, Is.False);
+                Assert.That(eo.TryGetEncodeable(out IEncodeable body), Is.True);
+                decoded = body as OptionSetEncoder;
+                Assert.That(decoded, Is.Not.Null, "Decoded body is not an OptionSet.");
+            }
+
+            Assert.That(decoded.Value.Span.ToArray(),
+                Is.EqualTo(source.Value.Span.ToArray()));
+            Assert.That(decoded.ValidBits.Span.ToArray(),
+                Is.EqualTo(source.ValidBits.Span.ToArray()));
+            Assert.That(decoded["CurrentWrite"], Is.True);
+            Assert.That(decoded["HistoryRead"], Is.True);
+            Assert.That(decoded["CurrentRead"], Is.False);
+            Assert.That(decoded["HistoryWrite"], Is.False);
+        }
+
+        [Test]
+        public void WireFormatDecodesHandcraftedBytes()
+        {
+            EnumDefinition definition = CreateAccessRightsDefinition();
+            ITelemetryContext telemetry = NUnitTelemetryContext.Create();
+            IServiceMessageContext context = ServiceMessageContext.Create(telemetry);
+            context.NamespaceUris.GetIndexOrAppend(kTypeNamespace);
+
+            IEncodeableType type = m_builder.AddOptionSetType(
+                QualifiedName.From("AccessRights"),
+                s_typeId, s_binaryId, s_xmlId, ExpandedNodeId.Null,
+                definition);
+            context.Factory.Builder
+                .AddEncodeableType(s_binaryId, type)
+                .AddEncodeableType(s_typeId, type)
+                .AddEncodeableType(type)
+                .Commit();
+
+            // Build a body matching Part 6 encoding:
+            //   Value     : ByteString  [0x03]
+            //   ValidBits : ByteString  [0x03]
+            byte[] body;
+            using (var bodyStream = new MemoryStream())
+            using (var bodyEncoder = new BinaryEncoder(bodyStream, context, false))
+            {
+                bodyEncoder.WriteByteString(null, new byte[] { 0x03 });
+                bodyEncoder.WriteByteString(null, new byte[] { 0x03 });
+                body = bodyStream.ToArray();
+            }
+
+            var eo = new ExtensionObject(s_binaryId, ByteString.From(body));
+            byte[] buffer;
+            using (var stream = new MemoryStream())
+            using (var encoder = new BinaryEncoder(stream, context, false))
+            {
+                encoder.WriteExtensionObject("os", eo);
+                buffer = stream.ToArray();
+            }
+
+            using var decodeStream = new MemoryStream(buffer);
+            using var decoder = new BinaryDecoder(decodeStream, context);
+            ExtensionObject decodedEo = decoder.ReadExtensionObject("os");
+            Assert.That(decodedEo.TryGetEncodeable(out IEncodeable decodedBody), Is.True);
+            var decoded = decodedBody as OptionSetEncoder;
+            Assert.That(decoded, Is.Not.Null);
+            Assert.That(decoded[0], Is.True);
+            Assert.That(decoded[1], Is.True);
+            Assert.That(decoded[2], Is.False);
+            Assert.That(
+                decoded.GetSetFieldNames(),
+                Is.EqualTo(new[] { "CurrentRead", "CurrentWrite" }));
+        }
+
+        [Test]
+        public void CreateInstanceProducesFreshInstance()
+        {
+            EnumDefinition definition = CreateAccessRightsDefinition();
+            IEncodeableType type = m_builder.AddOptionSetType(
+                QualifiedName.From("AccessRights"),
+                s_typeId, s_binaryId, s_xmlId, ExpandedNodeId.Null,
+                definition);
+
+            var a = (OptionSetEncoder)type.CreateInstance();
+            a["CurrentRead"] = true;
+            var b = (OptionSetEncoder)type.CreateInstance();
+
+            Assert.That(b.Value.IsEmpty, Is.True);
+            Assert.That(b.ValidBits.IsEmpty, Is.True);
+            Assert.That(a.Definition, Is.SameAs(b.Definition));
+        }
+
+        [Test]
+        public void CloneProducesIndependentCopy()
+        {
+            EnumDefinition definition = CreateAccessRightsDefinition();
+            var optionSet = new OptionSetEncoder(
+                new XmlQualifiedName("AccessRights", kTypeNamespace),
+                s_typeId, s_binaryId, s_xmlId, ExpandedNodeId.Null,
+                definition);
+            optionSet["HistoryRead"] = true;
+
+            var clone = (OptionSetEncoder)optionSet.Clone();
+            Assert.That(clone, Is.Not.SameAs(optionSet));
+            Assert.That(clone["HistoryRead"], Is.True);
+
+            clone["CurrentRead"] = true;
+            Assert.That(optionSet["CurrentRead"], Is.False,
+                "Mutating the clone must not affect the source.");
+        }
+
+        [Test]
+        public void ByteLengthIsDerivedFromHighestBit()
+        {
+            // Bits 0..3 => ceil(4 / 8) = 1 byte.
+            var oneByte = new OptionSetEncoder(
+                new XmlQualifiedName("AccessRights", kTypeNamespace),
+                s_typeId, s_binaryId, s_xmlId, ExpandedNodeId.Null,
+                CreateAccessRightsDefinition());
+            Assert.That(oneByte.ByteLength, Is.EqualTo(1));
+
+            // Bit 10 => ceil(11 / 8) = 2 bytes.
+            var twoBytes = new OptionSetEncoder(
+                new XmlQualifiedName("TwoByteOptionSet", kTypeNamespace),
+                s_typeId, s_binaryId, s_xmlId, ExpandedNodeId.Null,
+                new EnumDefinition
+                {
+                    IsOptionSet = true,
+                    Fields =
+                    [
+                        new EnumField { Name = "Bit0", Value = 0 },
+                        new EnumField { Name = "Bit10", Value = 10 }
+                    ]
+                });
+            Assert.That(twoBytes.ByteLength, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void SetBitOutsideFixedLengthThrows()
+        {
+            // AccessRights-style OptionSet has max bit 3, so ByteLength == 1.
+            var optionSet = new OptionSetEncoder(
+                new XmlQualifiedName("AccessRights", kTypeNamespace),
+                s_typeId, s_binaryId, s_xmlId, ExpandedNodeId.Null,
+                CreateAccessRightsDefinition());
+
+            // Bit 8 is outside the 1-byte fixed length — must throw per Part 3 §8.40.
+            Assert.That(
+                () => optionSet[8] = true,
+                Throws.TypeOf<System.ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void SetBitPadsValueAndValidBitsToFixedLength()
+        {
+            // Max bit 10 => ByteLength 2.
+            var optionSet = new OptionSetEncoder(
+                new XmlQualifiedName("TwoByteOptionSet", kTypeNamespace),
+                s_typeId, s_binaryId, s_xmlId, ExpandedNodeId.Null,
+                new EnumDefinition
+                {
+                    IsOptionSet = true,
+                    Fields =
+                    [
+                        new EnumField { Name = "Bit0", Value = 0 },
+                        new EnumField { Name = "Bit10", Value = 10 }
+                    ]
+                });
+
+            optionSet[0] = true;
+
+            // Even though we only touched byte 0, the fixed-length invariant
+            // means Value and ValidBits are materialized to 2 bytes.
+            Assert.That(optionSet.Value.Length, Is.EqualTo(2));
+            Assert.That(optionSet.ValidBits.Length, Is.EqualTo(2));
+        }
+    }
+}


### PR DESCRIPTION
Concrete sub-types of the abstract OptionSet DataType (i=12755, e.g. AccessRights, CarExtras, OptionSetBase) were silently skipped by ComplexTypeSystem.LoadBaseStructureDataTypesAsync when only an EnumDefinition or OptionSetValues property was available. This change registers them with a new runtime class Opc.Ua.Encoders.OptionSet that reuses the generated Opc.Ua.OptionSet wire format (Value/ValidBits ByteStrings) and self-registers via IEncodeableType.

Key changes:

- New Stack/Opc.Ua/Types/OptionSet.cs with EnumDefinition-driven bit accessors (by name and index), GetSetFieldNames helper, and a fixed ByteLength derived from the highest declared bit per OPC UA Part 3 paragraph 8.40 / 3.2.8. SetBit throws ArgumentOutOfRangeException outside that range and always materializes Value/ValidBits to the fixed length.

- New AddOptionSetType entry point on IComplexTypeBuilder (source-breaking addition for custom implementations); DefaultComplexTypeBuilder implements it. The Reflection.Emit ComplexTypeBuilder throws NotSupportedException.

- ComplexTypeSystem detects OptionSet descendants via a HasSubtype walk and resolves the EnumDefinition from DataTypeDefinition or the OptionSetValues property fallback before the old skip path.

- Removed stale V1.04 OptionSet limitation remark from ComplexTypeSystem.

- 10 unit tests in Tests/Opc.Ua.Client.Tests/ComplexTypes/DefaultOptionSetTests.cs covering factory registration, bit accessors, binary round-trip via ExtensionObject, hand-crafted Part 6 wire format, Clone/CreateInstance semantics, and the ByteLength invariant.

- Live-verified against opc.tcp://DESKTOP-BGFJS91:48010 (UA C++ SDK demo): AccessRights/CarExtras/OptionSetBase now appear in the registered custom-type list; no skip-log entries; LoadAsync(throwOnError:true) returns true.

- Docs/ComplexTypes.md Known Limitations reworded; Docs/MigrationGuide.md gains an OptionSet DataType support subsection.

UInteger-backed OptionSet DataTypes remain intentionally opaque (carried as their unsigned integer in a Variant).

## Proposed changes

Describe the changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Related Issues

- Fixes #

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
