### PR TITLE
Fix boolean default should be false instead of true

### DIFF
--- a/Applications/ConsoleReferencePublisher/Program.cs
+++ b/Applications/ConsoleReferencePublisher/Program.cs
@@ -277,6 +277,7 @@ namespace Quickstarts.ConsoleReferencePublisher
             //create  the PubSub configuration root object
             return new PubSubConfigurationDataType
             {
+                Enabled = true,
                 Connections = [pubSubConnection1],
                 PublishedDataSets = [publishedDataSetSimple, publishedDataSetAllTypes]
             };
@@ -419,6 +420,7 @@ namespace Quickstarts.ConsoleReferencePublisher
             //create  the PubSub configuration root object
             return new PubSubConfigurationDataType
             {
+                Enabled = true,
                 Connections = [pubSubConnection1],
                 PublishedDataSets = [publishedDataSetSimple, publishedDataSetAllTypes]
             };
@@ -557,6 +559,7 @@ namespace Quickstarts.ConsoleReferencePublisher
             //create  the PubSub configuration root object
             return new PubSubConfigurationDataType
             {
+                Enabled = true,
                 Connections = [pubSubConnection1],
                 PublishedDataSets = [publishedDataSetSimple, publishedDataSetAllTypes]
             };

--- a/Applications/ConsoleReferenceSubscriber/Program.cs
+++ b/Applications/ConsoleReferenceSubscriber/Program.cs
@@ -478,7 +478,7 @@ namespace Quickstarts.ConsoleReferenceSubscriber
             pubSubConnection1.ReaderGroups = pubSubConnection1.ReaderGroups.AddItem(readerGroup1);
 
             //create  pub sub configuration root object
-            return new PubSubConfigurationDataType { Connections = [pubSubConnection1] };
+            return new PubSubConfigurationDataType { Enabled = true, Connections = [pubSubConnection1] };
         }
 
         /// <summary>
@@ -645,7 +645,7 @@ namespace Quickstarts.ConsoleReferenceSubscriber
             pubSubConnection1.ReaderGroups = pubSubConnection1.ReaderGroups.AddItem(readerGroup1);
 
             //create  pub sub configuration root object
-            return new PubSubConfigurationDataType { Connections = [pubSubConnection1] };
+            return new PubSubConfigurationDataType { Enabled = true, Connections = [pubSubConnection1] };
         }
 
         /// <summary>
@@ -807,7 +807,7 @@ namespace Quickstarts.ConsoleReferenceSubscriber
             pubSubConnection1.ReaderGroups = pubSubConnection1.ReaderGroups.AddItem(readerGroup1);
 
             //create  pub sub configuration root object
-            return new PubSubConfigurationDataType { Connections = [pubSubConnection1] };
+            return new PubSubConfigurationDataType { Enabled = true, Connections = [pubSubConnection1] };
         }
 
         /// <summary>

--- a/Docs/MigrationGuide.md
+++ b/Docs/MigrationGuide.md
@@ -49,6 +49,7 @@
       - [Encoding format is not guaranteed backward compatible](#encoding-format-is-not-guaranteed-backward-compatible)
       - [OptionSet DataType support](#optionset-datatype-support)
     - [Other Breaking Changes](#other-breaking-changes)
+      - [Boolean default values in source-generated data types](#boolean-default-values-in-source-generated-data-types)
   - [Migrating from 1.05.377 to 1.05.378](#migrating-from-105377-to-105378)
     - [Asynchronous as default](#asynchronous-as-default)
     - [Observability](#observability)
@@ -681,6 +682,47 @@ When migrating code that previously set `Identity` directly, no code changes are
 #### Encoding format is not guaranteed backward compatible
 
 The encoding format for session state has changed. Existing persisted session state files **cannot** be loaded by the new `SessionConfiguration.Create()` method. Handle restore failures and re-persist the new session state.
+
+### Other Breaking Changes
+
+#### Boolean default values in source-generated data types
+
+**Breaking Change**: Boolean properties on source-generated data types now correctly default to `false` instead of `true`.
+
+Previous versions contained a bug in the source generator that inverted the default value for boolean fields in generated data types. Boolean fields without an explicit `<DefaultValue>` in the model design XML were initialized to `true` instead of the correct `false`. This has been fixed.
+
+**Impact**: Any code that creates instances of source-generated data types and relies on boolean properties being `true` by default must now explicitly set those properties to `true`. This primarily affects PubSub configuration types:
+
+| Type | Property | Old Default | New Default |
+|---|---|---|---|
+| `PubSubConfigurationDataType` | `Enabled` | `true` | `false` |
+| `PubSubConnectionDataType` | `Enabled` | `true` | `false` |
+| `WriterGroupDataType` | `Enabled` | `true` | `false` |
+| `ReaderGroupDataType` | `Enabled` | `true` | `false` |
+| `DataSetWriterDataType` | `Enabled` | `true` | `false` |
+| `DataSetReaderDataType` | `Enabled` | `true` | `false` |
+| `PublishedDataSetCustomSourceDataType` | `CyclicDataSet` | `true` | `false` |
+
+Other affected types include all source-generated structures with boolean fields (e.g., `AggregateConfiguration.TreatUncertainAsBad`, `MonitoringParameters.DiscardOldest`, `CreateSubscriptionRequest.PublishingEnabled`).
+
+> **Note:** Hand-written types in `Opc.Ua.Types` (such as `BrowseDescription`, `RelativePathElement`) are **not** affected — they already had explicit initialization in their constructors.
+
+**Migration**: Add explicit initialization where your code depends on `true` as the default:
+
+```csharp
+// Before (relied on incorrect true default)
+var connection = new PubSubConnectionDataType
+{
+    Name = "MyConnection"
+};
+
+// After (explicitly set Enabled)
+var connection = new PubSubConnectionDataType
+{
+    Enabled = true,
+    Name = "MyConnection"
+};
+```
 
 ## Migrating from 1.05.377 to 1.05.378
 

--- a/Docs/MigrationGuide.md
+++ b/Docs/MigrationGuide.md
@@ -689,7 +689,7 @@ The encoding format for session state has changed. Existing persisted session st
 
 **Breaking Change**: Boolean properties on source-generated data types now correctly default to `false` instead of `true`.
 
-Previous versions contained a bug in the source generator that inverted the default value for boolean fields in generated data types. Boolean fields without an explicit `<DefaultValue>` in the model design XML were initialized to `true` instead of the correct `false`. This has been fixed.
+Generated code produced by the model compiler contained a bug because it inverted the default value for boolean fields in generated data types. Boolean fields without an explicit `<DefaultValue>` in the model design XML were initialized to `true` instead of `false` as expected and defined in Part 6. This has been fixed.
 
 **Impact**: Any code that creates instances of source-generated data types and relies on boolean properties being `true` by default must now explicitly set those properties to `true`. This primarily affects PubSub configuration types:
 
@@ -703,9 +703,8 @@ Previous versions contained a bug in the source generator that inverted the defa
 | `DataSetReaderDataType` | `Enabled` | `true` | `false` |
 | `PublishedDataSetCustomSourceDataType` | `CyclicDataSet` | `true` | `false` |
 
-Other affected types include all source-generated structures with boolean fields (e.g., `AggregateConfiguration.TreatUncertainAsBad`, `MonitoringParameters.DiscardOldest`, `CreateSubscriptionRequest.PublishingEnabled`).
-
-> **Note:** Hand-written types in `Opc.Ua.Types` (such as `BrowseDescription`, `RelativePathElement`) are **not** affected — they already had explicit initialization in their constructors.
+Other affected types include all source-generated structures with boolean fields (e.g., `AggregateConfiguration.TreatUncertainAsBad`, `MonitoringParameters.DiscardOldest`, `CreateSubscriptionRequest.PublishingEnabled`) as well as 
+some hand-written types in `Opc.Ua.Types` (such as `BrowseDescription`, `RelativePathElement`).
 
 **Migration**: Add explicit initialization where your code depends on `true` as the default:
 

--- a/Libraries/Opc.Ua.PubSub/Configuration/UaPubSubConfigurationHelper.cs
+++ b/Libraries/Opc.Ua.PubSub/Configuration/UaPubSubConfigurationHelper.cs
@@ -78,7 +78,7 @@ namespace Opc.Ua.PubSub.Configuration
                     ServiceMessageContext.CreateEmpty(telemetry);
                 using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
                 using var parser = new XmlParser(typeof(PubSubConfigurationDataType), stream, context);
-                var config = new PubSubConfigurationDataType();
+                var config = new PubSubConfigurationDataType { Enabled = true };
                 config.Decode(parser);
                 return config;
             }

--- a/Libraries/Opc.Ua.PubSub/Configuration/UaPubSubConfigurator.cs
+++ b/Libraries/Opc.Ua.PubSub/Configuration/UaPubSubConfigurator.cs
@@ -146,6 +146,7 @@ namespace Opc.Ua.PubSub.Configuration
 
             PubSubConfiguration = new PubSubConfigurationDataType
             {
+                Enabled = true,
                 Connections = [],
                 PublishedDataSets = []
             };

--- a/Libraries/Opc.Ua.PubSub/UaPubSubApplication.cs
+++ b/Libraries/Opc.Ua.PubSub/UaPubSubApplication.cs
@@ -169,7 +169,7 @@ namespace Opc.Ua.PubSub
         /// <returns>New instance of <see cref="UaPubSubApplication"/></returns>
         public static UaPubSubApplication Create(IUaPubSubDataStore dataStore, ITelemetryContext telemetry)
         {
-            return Create(new PubSubConfigurationDataType(), dataStore, telemetry);
+            return Create(new PubSubConfigurationDataType { Enabled = true }, dataStore, telemetry);
         }
 
         /// <summary>
@@ -246,7 +246,7 @@ namespace Opc.Ua.PubSub
             ITelemetryContext telemetry)
         {
             // if no argument received, start with empty configuration
-            pubSubConfiguration ??= new PubSubConfigurationDataType();
+            pubSubConfiguration ??= new PubSubConfigurationDataType { Enabled = true };
 
             var uaPubSubApplication = new UaPubSubApplication(telemetry, dataStore);
             uaPubSubApplication.UaPubSubConfigurator.LoadConfiguration(pubSubConfiguration);

--- a/Tests/Opc.Ua.PubSub.Tests/Configuration/PubSubConfiguratorTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Configuration/PubSubConfiguratorTests.cs
@@ -115,7 +115,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         {
             int expected = CallCountConnectionAdded + 1;
             StatusCode result = m_uaPubSubConfigurator.AddConnection(
-                new PubSubConnectionDataType());
+                new PubSubConnectionDataType { Enabled = true });
             Assert.That(StatusCode.IsGood(result), Is.True, "Status code received: " + result);
             Assert.That(
                 CallCountConnectionAdded,
@@ -128,11 +128,11 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         )]
         public void ValidateAddConnectionReturnsBadBrowseNameDuplicated()
         {
-            var connection1 = new PubSubConnectionDataType { Name = "Name" };
+            var connection1 = new PubSubConnectionDataType { Enabled = true, Name = "Name" };
             StatusCode result = m_uaPubSubConfigurator.AddConnection(connection1);
             Assert.That(StatusCode.IsGood(result), Is.True, "Status code received: " + result);
 
-            var connection2 = new PubSubConnectionDataType { Name = "Name" };
+            var connection2 = new PubSubConnectionDataType { Enabled = true, Name = "Name" };
             result = m_uaPubSubConfigurator.AddConnection(connection2);
 
             Assert.That(
@@ -146,7 +146,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test(Description = "Validate AddConnection throws ArgumentException if a connection is added twice")]
         public void ValidateAddConnectionThrowsArgumentException()
         {
-            var connection1 = new PubSubConnectionDataType { Name = "Name" };
+            var connection1 = new PubSubConnectionDataType { Enabled = true, Name = "Name" };
             StatusCode result = m_uaPubSubConfigurator.AddConnection(connection1);
             Assert.That(StatusCode.IsGood(result), Is.True, "Status code received: " + result);
 
@@ -159,7 +159,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         public void ValidateConnectionRemoved()
         {
             int expected = CallCountConnectionRemoved + 1;
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
             Assert.That(
@@ -214,13 +214,13 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         public void ValidateReaderGroupAdded()
         {
             int expected = CallCountReaderGroupAdded + 1;
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
             Assert.That(
                 StatusCode.IsGood(m_uaPubSubConfigurator.AddReaderGroup(
                     lastAddedConnId,
-                    new ReaderGroupDataType())),
+                    new ReaderGroupDataType { Enabled = true })),
                 Is.True);
             Assert.That(CallCountReaderGroupAdded, Is.EqualTo(expected).Within(0));
         }
@@ -229,10 +229,10 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         public void ValidateReaderGroupRemoved()
         {
             int expected = CallCountReaderGroupRemoved + 1;
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
-            var readerGroup = new ReaderGroupDataType();
+            var readerGroup = new ReaderGroupDataType { Enabled = true };
             Assert.That(StatusCode.IsGood(
                 m_uaPubSubConfigurator.AddReaderGroup(lastAddedConnId, readerGroup)), Is.True);
             Assert.That(StatusCode.IsGood(m_uaPubSubConfigurator.RemoveReaderGroup(readerGroup)), Is.True);
@@ -242,10 +242,10 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test(Description = "Validate AddReaderGroup throws ArgumentException if a reader-group is added twice")]
         public void ValidateAddReaderGroupThrowsArgumentExceptionIfAddedTwice()
         {
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
-            var readerGroup1 = new ReaderGroupDataType { Name = "Name" };
+            var readerGroup1 = new ReaderGroupDataType { Enabled = true, Name = "Name" };
             StatusCode result = m_uaPubSubConfigurator.AddReaderGroup(
                 lastAddedConnId,
                 readerGroup1);
@@ -261,14 +261,14 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         )]
         public void ValidateAddReaderGroupReturnsBadBrowseNameDuplicated()
         {
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
-            var readerGroup = new ReaderGroupDataType { Name = "Name" };
+            var readerGroup = new ReaderGroupDataType { Enabled = true, Name = "Name" };
             StatusCode result = m_uaPubSubConfigurator.AddReaderGroup(lastAddedConnId, readerGroup);
             Assert.That(StatusCode.IsGood(result), Is.True, "Status code received: " + result);
 
-            var readerGroup2 = new ReaderGroupDataType { Name = "Name" };
+            var readerGroup2 = new ReaderGroupDataType { Enabled = true, Name = "Name" };
             result = m_uaPubSubConfigurator.AddReaderGroup(lastAddedConnId, readerGroup2);
 
             Assert.That(
@@ -284,7 +284,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         )]
         public void ValidateAddReaderGroupReturnsBadInvalidArgument()
         {
-            var readerGroup = new ReaderGroupDataType { Name = "Name" };
+            var readerGroup = new ReaderGroupDataType { Enabled = true, Name = "Name" };
             StatusCode result = m_uaPubSubConfigurator.AddReaderGroup(1, readerGroup);
             Assert.That(
                 result,
@@ -297,7 +297,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         public void ValidateAddReaderGroupThrowsArgumentExceptionIfInvalidParent()
         {
             const uint lastAddedConnId = 7;
-            var readerGroup = new ReaderGroupDataType { Name = "Name" };
+            var readerGroup = new ReaderGroupDataType { Enabled = true, Name = "Name" };
             Assert.Throws<ArgumentException>(
                 () => m_uaPubSubConfigurator.AddReaderGroup(lastAddedConnId, readerGroup),
                 "AddReaderGroup shall throw ArgumentException if readerGroup is added to invalid parent id");
@@ -307,13 +307,13 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         public void ValidateWriterGroupAdded()
         {
             int expected = CallCountWriterGroupAdded + 1;
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
             Assert.That(
                 StatusCode.IsGood(m_uaPubSubConfigurator.AddWriterGroup(
                     lastAddedConnId,
-                    new WriterGroupDataType())),
+                    new WriterGroupDataType { Enabled = true })),
                 Is.True);
             Assert.That(CallCountWriterGroupAdded, Is.EqualTo(expected).Within(0));
         }
@@ -322,10 +322,10 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         public void ValidateWriterGroupRemoved()
         {
             int expected = CallCountWriterGroupRemoved + 1;
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
-            var writerGrp = new WriterGroupDataType();
+            var writerGrp = new WriterGroupDataType { Enabled = true };
             Assert.That(
                 StatusCode.IsGood(
                     m_uaPubSubConfigurator.AddWriterGroup(lastAddedConnId, writerGrp)),
@@ -339,16 +339,16 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         )]
         public void ValidateAddWriterGroupReturnsBadBrowseNameDuplicated()
         {
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
-            var writerGroup1 = new WriterGroupDataType { Name = "Name" };
+            var writerGroup1 = new WriterGroupDataType { Enabled = true, Name = "Name" };
             StatusCode result = m_uaPubSubConfigurator.AddWriterGroup(
                 lastAddedConnId,
                 writerGroup1);
             Assert.That(StatusCode.IsGood(result), Is.True, "Status code received: " + result);
 
-            var writerGroup2 = new WriterGroupDataType { Name = "Name" };
+            var writerGroup2 = new WriterGroupDataType { Enabled = true, Name = "Name" };
             result = m_uaPubSubConfigurator.AddWriterGroup(lastAddedConnId, writerGroup2);
 
             Assert.That(
@@ -362,7 +362,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         )]
         public void ValidateAddWriterGroupReturnsBadInvalidArgument()
         {
-            var writerGroup1 = new WriterGroupDataType { Name = "Name" };
+            var writerGroup1 = new WriterGroupDataType { Enabled = true, Name = "Name" };
             StatusCode result = m_uaPubSubConfigurator.AddWriterGroup(1, writerGroup1);
             Assert.That(
                 result,
@@ -373,10 +373,10 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test(Description = "Validate AddWriterGroup throws ArgumentException if a WriterGroup is added twice")]
         public void ValidateAddWriterGroupThrowsArgumentExceptionIfAddedTwice()
         {
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
-            var writerGroup1 = new WriterGroupDataType { Name = "Name" };
+            var writerGroup1 = new WriterGroupDataType { Enabled = true, Name = "Name" };
             StatusCode result = m_uaPubSubConfigurator.AddWriterGroup(
                 lastAddedConnId,
                 writerGroup1);
@@ -392,7 +392,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         public void ValidateAddWriterGroupThrowsArgumentExceptionIfInvalidParent()
         {
             const uint lastAddedConnId = 7;
-            var writerGroup1 = new WriterGroupDataType { Name = "Name" };
+            var writerGroup1 = new WriterGroupDataType { Enabled = true, Name = "Name" };
             Assert.Throws<ArgumentException>(
                 () => m_uaPubSubConfigurator.AddWriterGroup(lastAddedConnId, writerGroup1),
                 "AddWriterGroup shall throw ArgumentException if writerGroup is added to invalid parent id");
@@ -402,11 +402,11 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         public void ValidateDataSetReaderAdded()
         {
             int expected = CallCountDataSetReaderAdded + 1;
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
 
-            var newReaderGroup = new ReaderGroupDataType();
+            var newReaderGroup = new ReaderGroupDataType { Enabled = true };
             m_uaPubSubConfigurator.AddReaderGroup(lastAddedConnId, newReaderGroup);
             uint lastAddedReaderGroupId = m_uaPubSubConfigurator.FindIdForObject(newReaderGroup);
 
@@ -414,7 +414,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
                 StatusCode.IsGood(
                     m_uaPubSubConfigurator.AddDataSetReader(
                         lastAddedReaderGroupId,
-                        new DataSetReaderDataType())),
+                        new DataSetReaderDataType { Enabled = true })),
                 Is.True);
             Assert.That(CallCountDataSetReaderAdded, Is.EqualTo(expected).Within(0));
         }
@@ -423,15 +423,15 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         public void ValidateDataSetReaderRemoved()
         {
             int expected = CallCountDataSetReaderRemoved + 1;
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
 
-            var newReaderGroup = new ReaderGroupDataType();
+            var newReaderGroup = new ReaderGroupDataType { Enabled = true };
             m_uaPubSubConfigurator.AddReaderGroup(lastAddedConnId, newReaderGroup);
             uint lastAddedReaderGroupId = m_uaPubSubConfigurator.FindIdForObject(newReaderGroup);
 
-            var dsReader = new DataSetReaderDataType();
+            var dsReader = new DataSetReaderDataType { Enabled = true };
 
             Assert.That(StatusCode.IsGood(
                 m_uaPubSubConfigurator.AddDataSetReader(lastAddedReaderGroupId, dsReader)), Is.True);
@@ -444,21 +444,21 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         )]
         public void ValidateAddDataSetReaderReturnsBadBrowseNameDuplicated()
         {
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
-            var readerGroup1 = new ReaderGroupDataType { Name = "Name" };
+            var readerGroup1 = new ReaderGroupDataType { Enabled = true, Name = "Name" };
             StatusCode result = m_uaPubSubConfigurator.AddReaderGroup(
                 lastAddedConnId,
                 readerGroup1);
             Assert.That(StatusCode.IsGood(result), Is.True, "Status code received: " + result);
 
             uint lastAddedGroup = m_uaPubSubConfigurator.FindIdForObject(readerGroup1);
-            var reader1 = new DataSetReaderDataType { Name = "Name" };
+            var reader1 = new DataSetReaderDataType { Enabled = true, Name = "Name" };
             result = m_uaPubSubConfigurator.AddDataSetReader(lastAddedGroup, reader1);
             Assert.That(StatusCode.IsGood(result), Is.True, "Status code received: " + result);
 
-            var reader2 = new DataSetReaderDataType { Name = "Name" };
+            var reader2 = new DataSetReaderDataType { Enabled = true, Name = "Name" };
             result = m_uaPubSubConfigurator.AddDataSetReader(lastAddedGroup, reader2);
 
             Assert.That(
@@ -470,17 +470,17 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test(Description = "Validate AddDataSetReader throws ArgumentException if a dataset-reader is added twice")]
         public void ValidateAddDataSetReaderThrowsArgumentException()
         {
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
-            var readerGroup1 = new ReaderGroupDataType { Name = "Name" };
+            var readerGroup1 = new ReaderGroupDataType { Enabled = true, Name = "Name" };
             StatusCode result = m_uaPubSubConfigurator.AddReaderGroup(
                 lastAddedConnId,
                 readerGroup1);
             Assert.That(StatusCode.IsGood(result), Is.True, "Status code received: " + result);
 
             uint lastAddedGroup = m_uaPubSubConfigurator.FindIdForObject(readerGroup1);
-            var reader1 = new DataSetReaderDataType { Name = "Name" };
+            var reader1 = new DataSetReaderDataType { Enabled = true, Name = "Name" };
             result = m_uaPubSubConfigurator.AddDataSetReader(lastAddedGroup, reader1);
             Assert.That(StatusCode.IsGood(result), Is.True, "Status code received: " + result);
 
@@ -494,7 +494,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         )]
         public void ValidateAddDataSetReaderReturnsBadInvalidArgument()
         {
-            var reader1 = new DataSetReaderDataType { Name = "Name" };
+            var reader1 = new DataSetReaderDataType { Enabled = true, Name = "Name" };
             StatusCode result = m_uaPubSubConfigurator.AddDataSetReader(1, reader1);
             Assert.That(
                 result,
@@ -506,12 +506,12 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         public void ValidateDataSetWriterAdded()
         {
             int expected = CallCountDataSetWriterAdded + 1;
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
 
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
 
-            var newWriterGroup = new WriterGroupDataType();
+            var newWriterGroup = new WriterGroupDataType { Enabled = true };
             m_uaPubSubConfigurator.AddWriterGroup(lastAddedConnId, newWriterGroup);
             uint lastAddedWriterGroupId = m_uaPubSubConfigurator.FindIdForObject(newWriterGroup);
 
@@ -519,7 +519,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
                 StatusCode.IsGood(
                     m_uaPubSubConfigurator.AddDataSetWriter(
                         lastAddedWriterGroupId,
-                        new DataSetWriterDataType())),
+                        new DataSetWriterDataType { Enabled = true })),
                 Is.True);
             Assert.That(CallCountDataSetWriterAdded, Is.EqualTo(expected).Within(0));
         }
@@ -528,16 +528,16 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         public void ValidateDataSetWriterRemoved()
         {
             int expected = CallCountDataSetWriterRemoved + 1;
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
 
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
 
-            var newWriterGroup = new WriterGroupDataType();
+            var newWriterGroup = new WriterGroupDataType { Enabled = true };
             m_uaPubSubConfigurator.AddWriterGroup(lastAddedConnId, newWriterGroup);
             uint lastAddedWriterGroupId = m_uaPubSubConfigurator.FindIdForObject(newWriterGroup);
 
-            var dsWriter = new DataSetWriterDataType();
+            var dsWriter = new DataSetWriterDataType { Enabled = true };
             Assert.That(StatusCode.IsGood(
                 m_uaPubSubConfigurator.AddDataSetWriter(lastAddedWriterGroupId, dsWriter)), Is.True);
             Assert.That(StatusCode.IsGood(m_uaPubSubConfigurator.RemoveDataSetWriter(dsWriter)), Is.True);
@@ -549,21 +549,21 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         )]
         public void ValidateAddDataSetWriterReturnsBadBrowseNameDuplicated()
         {
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
-            var writerGroup1 = new WriterGroupDataType { Name = "Name" };
+            var writerGroup1 = new WriterGroupDataType { Enabled = true, Name = "Name" };
             StatusCode result = m_uaPubSubConfigurator.AddWriterGroup(
                 lastAddedConnId,
                 writerGroup1);
             Assert.That(StatusCode.IsGood(result), Is.True, "Status code received: " + result);
 
             uint lastAddedGroup = m_uaPubSubConfigurator.FindIdForObject(writerGroup1);
-            var writer1 = new DataSetWriterDataType { Name = "Name" };
+            var writer1 = new DataSetWriterDataType { Enabled = true, Name = "Name" };
             result = m_uaPubSubConfigurator.AddDataSetWriter(lastAddedGroup, writer1);
             Assert.That(StatusCode.IsGood(result), Is.True, "Status code received: " + result);
 
-            var writer2 = new DataSetWriterDataType { Name = "Name" };
+            var writer2 = new DataSetWriterDataType { Enabled = true, Name = "Name" };
             result = m_uaPubSubConfigurator.AddDataSetWriter(lastAddedGroup, writer2);
 
             Assert.That(
@@ -575,17 +575,17 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test(Description = "Validate AddDataSetWriter throws ArgumentException if a dataset-reader is added twice")]
         public void ValidateAddDataSetWriterThrowsArgumentException()
         {
-            var newConnection = new PubSubConnectionDataType();
+            var newConnection = new PubSubConnectionDataType { Enabled = true };
             m_uaPubSubConfigurator.AddConnection(newConnection);
             uint lastAddedConnId = m_uaPubSubConfigurator.FindIdForObject(newConnection);
-            var writerGroup1 = new WriterGroupDataType { Name = "Name" };
+            var writerGroup1 = new WriterGroupDataType { Enabled = true, Name = "Name" };
             StatusCode result = m_uaPubSubConfigurator.AddWriterGroup(
                 lastAddedConnId,
                 writerGroup1);
             Assert.That(StatusCode.IsGood(result), Is.True, "Status code received: " + result);
 
             uint lastAddedGroup = m_uaPubSubConfigurator.FindIdForObject(writerGroup1);
-            var writer1 = new DataSetWriterDataType { Name = "Name" };
+            var writer1 = new DataSetWriterDataType { Enabled = true, Name = "Name" };
             result = m_uaPubSubConfigurator.AddDataSetWriter(lastAddedGroup, writer1);
             Assert.That(StatusCode.IsGood(result), Is.True, "Status code received: " + result);
 
@@ -599,7 +599,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         )]
         public void ValidateAddDataSetWriterReturnsBadInvalidArgument()
         {
-            var writer1 = new DataSetWriterDataType { Name = "Name" };
+            var writer1 = new DataSetWriterDataType { Enabled = true, Name = "Name" };
             StatusCode result = m_uaPubSubConfigurator.AddDataSetWriter(1, writer1);
             Assert.That(
                 result,
@@ -892,6 +892,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
             // and UaPubSubConfigurator
             var appConfPubSubConfiguration = new PubSubConfigurationDataType
             {
+                Enabled = true,
                 Connections = [],
                 PublishedDataSets = []
             };
@@ -922,6 +923,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
             // and UaPubSubConfigurator
             var appConfPubSubConfiguration = new PubSubConfigurationDataType
             {
+                Enabled = true,
                 Connections = [],
                 PublishedDataSets = []
             };
@@ -956,6 +958,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
             // and UaPubSubConfigurator
             var appConfPubSubConfiguration = new PubSubConfigurationDataType
             {
+                Enabled = true,
                 Connections = [],
                 PublishedDataSets = []
             };
@@ -1003,6 +1006,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
             // and UaPubSubConfigurator
             var appConfPubSubConfiguration = new PubSubConfigurationDataType
             {
+                Enabled = true,
                 Connections = [],
                 PublishedDataSets = []
             };
@@ -1053,6 +1057,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
             // and UaPubSubConfigurator
             var appConfPubSubConfiguration = new PubSubConfigurationDataType
             {
+                Enabled = true,
                 Connections = [],
                 PublishedDataSets = []
             };

--- a/Tests/Opc.Ua.PubSub.Tests/Configuration/PubSubStateMachineTests.StateChangeMethods.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Configuration/PubSubStateMachineTests.StateChangeMethods.cs
@@ -112,7 +112,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
             ITelemetryContext telemetry = NUnitTelemetryContext.Create();
             using var uaPubSubApplication = UaPubSubApplication.Create(m_publisherConfigurationFile, telemetry);
             UaPubSubConfigurator configurator = uaPubSubApplication.UaPubSubConfigurator;
-            var nonExisting = new PubSubConfigurationDataType();
+            var nonExisting = new PubSubConfigurationDataType { Enabled = true };
             Assert.Throws<ArgumentException>(
                 () => configurator.Enable(nonExisting),
                 "The Enable method does not throw exception when called with non existing parameter.");
@@ -124,7 +124,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
             ITelemetryContext telemetry = NUnitTelemetryContext.Create();
             using var uaPubSubApplication = UaPubSubApplication.Create(m_publisherConfigurationFile, telemetry);
             UaPubSubConfigurator configurator = uaPubSubApplication.UaPubSubConfigurator;
-            var nonExisting = new PubSubConfigurationDataType();
+            var nonExisting = new PubSubConfigurationDataType { Enabled = true };
             Assert.Throws<ArgumentException>(
                 () => configurator.Disable(nonExisting),
                 "The Disable method does not throw exception when called with non existing parameter.");

--- a/Tests/Opc.Ua.PubSub.Tests/Configuration/PubSubStateMachineTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Configuration/PubSubStateMachineTests.cs
@@ -127,7 +127,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         {
             UaPubSubConfigurator configurator = CreateConfigurator();
             Assert.Throws<ArgumentException>(
-                () => configurator.Enable(new PubSubConnectionDataType()));
+                () => configurator.Enable(new PubSubConnectionDataType { Enabled = true }));
         }
 
         [Test]
@@ -135,7 +135,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         {
             UaPubSubConfigurator configurator = CreateConfigurator();
             Assert.Throws<ArgumentException>(
-                () => configurator.Disable(new PubSubConnectionDataType()));
+                () => configurator.Disable(new PubSubConnectionDataType { Enabled = true }));
         }
 
         [Test]
@@ -253,7 +253,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         {
             UaPubSubConfigurator configurator = CreateConfigurator();
             PubSubState state = configurator.FindStateForObject(
-                new PubSubConnectionDataType());
+                new PubSubConnectionDataType { Enabled = true });
             Assert.That(state, Is.EqualTo(PubSubState.Error));
         }
 
@@ -269,7 +269,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         public void FindIdForUnknownObjectReturnsInvalidId()
         {
             UaPubSubConfigurator configurator = CreateConfigurator();
-            uint id = configurator.FindIdForObject(new PubSubConnectionDataType());
+            uint id = configurator.FindIdForObject(new PubSubConnectionDataType { Enabled = true });
             Assert.That(id, Is.EqualTo(UaPubSubConfigurator.InvalidId));
         }
 
@@ -286,7 +286,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         {
             UaPubSubConfigurator configurator = CreateConfigurator();
             object parent = configurator.FindParentForObject(
-                new PubSubConnectionDataType());
+                new PubSubConnectionDataType { Enabled = true });
             Assert.That(parent, Is.Null);
         }
 
@@ -295,7 +295,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         {
             UaPubSubConfigurator configurator = CreateConfigurator();
             List<uint> children = configurator.FindChildrenIdsForObject(
-                new PubSubConnectionDataType());
+                new PubSubConnectionDataType { Enabled = true });
             Assert.That(children, Is.Empty);
         }
 

--- a/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPubSubConfigurationHelperTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPubSubConfigurationHelperTests.cs
@@ -73,7 +73,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void SaveAndLoadEmptyConfiguration()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             string filePath = Path.Combine(m_tempDir, "empty_config.xml");
 
             UaPubSubConfigurationHelper.SaveConfiguration(config, filePath, m_telemetry);
@@ -86,7 +86,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void SaveAndLoadConfigurationWithConnection()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             var connection = new PubSubConnectionDataType
             {
                 Name = "TestConnection",
@@ -111,7 +111,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void SaveAndLoadConfigurationWithWriterGroup()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             var connection = new PubSubConnectionDataType
             {
                 Name = "WGConn",
@@ -145,7 +145,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void SaveAndLoadConfigurationWithPublishedDataSets()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             var pds = new PublishedDataSetDataType
             {
                 Name = "DataSet1",
@@ -203,12 +203,12 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         {
             string filePath = Path.Combine(m_tempDir, "overwrite.xml");
 
-            var config1 = new PubSubConfigurationDataType();
-            config1.Connections = config1.Connections.AddItem(new PubSubConnectionDataType { Name = "First" });
+            var config1 = new PubSubConfigurationDataType { Enabled = true };
+            config1.Connections = config1.Connections.AddItem(new PubSubConnectionDataType { Enabled = true, Name = "First" });
             UaPubSubConfigurationHelper.SaveConfiguration(config1, filePath, m_telemetry);
 
-            var config2 = new PubSubConfigurationDataType();
-            config2.Connections = config2.Connections.AddItem(new PubSubConnectionDataType { Name = "Second" });
+            var config2 = new PubSubConfigurationDataType { Enabled = true };
+            config2.Connections = config2.Connections.AddItem(new PubSubConnectionDataType { Enabled = true, Name = "Second" });
             UaPubSubConfigurationHelper.SaveConfiguration(config2, filePath, m_telemetry);
 
             PubSubConfigurationDataType loaded = UaPubSubConfigurationHelper.LoadConfiguration(filePath, m_telemetry);
@@ -218,7 +218,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void SaveAndLoadConfigurationWithReaderGroup()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             var connection = new PubSubConnectionDataType
             {
                 Name = "SubConn",
@@ -230,10 +230,12 @@ namespace Opc.Ua.PubSub.Tests.Configuration
 
             var readerGroup = new ReaderGroupDataType
             {
+                Enabled = true,
                 Name = "RG1"
             };
             var reader = new DataSetReaderDataType
             {
+                Enabled = true,
                 Name = "Reader1",
                 PublisherId = new Variant("Publisher1"),
                 WriterGroupId = 1,
@@ -266,7 +268,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void SaveAndLoadConfigurationWithMultipleConnections()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             for (int i = 0; i < 3; i++)
             {
                 config.Connections = config.Connections.AddItem(new PubSubConnectionDataType
@@ -292,7 +294,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void SaveAndLoadConfigurationPreservesDataSetWriterProperties()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             var connection = new PubSubConnectionDataType
             {
                 Name = "DswConn",

--- a/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPubSubConfiguratorCrudTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPubSubConfiguratorCrudTests.cs
@@ -64,14 +64,14 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddConnectionWithDuplicateNameReturnsBadBrowseNameDuplicated()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
-            var connection1 = new PubSubConnectionDataType { Name = "TestConnection" };
+            var connection1 = new PubSubConnectionDataType { Enabled = true, Name = "TestConnection" };
             StatusCode result1 = configurator.AddConnection(connection1);
             Assert.That(StatusCode.IsGood(result1), Is.True);
 
-            var connection2 = new PubSubConnectionDataType { Name = "TestConnection" };
+            var connection2 = new PubSubConnectionDataType { Enabled = true, Name = "TestConnection" };
             StatusCode result2 = configurator.AddConnection(connection2);
             Assert.That(result2.Code, Is.EqualTo(StatusCodes.BadBrowseNameDuplicated));
         }
@@ -79,12 +79,13 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddConnectionWithWriterGroupsProcessesSubGroups()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var connection = new PubSubConnectionDataType
             {
+                Enabled = true,
                 Name = "TestConnection",
                 WriterGroups = new ArrayOf<WriterGroupDataType>(new[] { writerGroup })
             };
@@ -96,12 +97,13 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddConnectionWithReaderGroupsProcessesSubGroups()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
-            var readerGroup = new ReaderGroupDataType { Name = "RG1" };
+            var readerGroup = new ReaderGroupDataType { Enabled = true, Name = "RG1" };
             var connection = new PubSubConnectionDataType
             {
+                Enabled = true,
                 Name = "TestConnection",
                 ReaderGroups = new ArrayOf<ReaderGroupDataType>(new[] { readerGroup })
             };
@@ -113,13 +115,14 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddConnectionWithEmptyNamedGroups()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
-            var writerGroup = new WriterGroupDataType { Name = "" };
-            var readerGroup = new ReaderGroupDataType { Name = "" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "" };
+            var readerGroup = new ReaderGroupDataType { Enabled = true, Name = "" };
             var connection = new PubSubConnectionDataType
             {
+                Enabled = true,
                 Name = "TestConnection",
                 WriterGroups = new ArrayOf<WriterGroupDataType>(new[] { writerGroup }),
                 ReaderGroups = new ArrayOf<ReaderGroupDataType>(new[] { readerGroup })
@@ -132,7 +135,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void RemoveConnectionByIdWithInvalidIdReturnsBadNodeIdUnknown()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             StatusCode result = configurator.RemoveConnection(9999);
@@ -142,7 +145,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddAndRemoveConnectionRoundTrip()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             bool connectionAddedFired = false;
@@ -156,7 +159,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
             };
             configurator.ConnectionRemoved += (s, e) => connectionRemovedFired = true;
 
-            var connection = new PubSubConnectionDataType { Name = "MyConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "MyConn" };
             StatusCode addResult = configurator.AddConnection(connection);
             Assert.That(StatusCode.IsGood(addResult), Is.True);
             Assert.That(connectionAddedFired, Is.True);
@@ -169,7 +172,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddPublishedDataSetAndRemove()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             bool addedFired = false;
@@ -196,7 +199,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void RemovePublishedDataSetByInvalidIdReturnsGood()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             StatusCode result = configurator.RemovePublishedDataSet(9999);
@@ -206,20 +209,22 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void RemovePublishedDataSetAlsoRemovesAssociatedWriters()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             var dataSet = new PublishedDataSetDataType { Name = "DS1" };
             configurator.AddPublishedDataSet(dataSet);
 
-            var writer = new DataSetWriterDataType { Name = "W1", DataSetName = "DS1" };
+            var writer = new DataSetWriterDataType { Enabled = true, Name = "W1", DataSetName = "DS1" };
             var writerGroup = new WriterGroupDataType
             {
+                Enabled = true,
                 Name = "WG1",
                 DataSetWriters = new ArrayOf<DataSetWriterDataType>(new[] { writer })
             };
             var connection = new PubSubConnectionDataType
             {
+                Enabled = true,
                 Name = "C1",
                 WriterGroups = new ArrayOf<WriterGroupDataType>(new[] { writerGroup })
             };
@@ -232,7 +237,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddExtensionFieldAndRemove()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             uint dataSetId = 0;
@@ -269,7 +274,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddExtensionFieldWithDuplicateNameReturnsBadNodeIdExists()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             uint dataSetId = 0;
@@ -297,7 +302,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddExtensionFieldWithInvalidDataSetIdReturnsBadNodeIdInvalid()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             var field = new KeyValuePair
@@ -312,7 +317,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void RemoveExtensionFieldWithInvalidIdsReturnsBadNodeIdInvalid()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             StatusCode result = configurator.RemoveExtensionField(9999, 8888);
@@ -322,7 +327,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddPublishedDataSetWithExtensionFieldsProcessesThem()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             var field = new KeyValuePair
@@ -343,7 +348,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddPublishedDataSetWithDuplicateNameReturnsBadBrowseNameDuplicated()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             var ds1 = new PublishedDataSetDataType { Name = "SameName" };
@@ -358,20 +363,20 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddWriterGroupWithDuplicateNameReturnsBadBrowseNameDuplicated()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             uint connectionId = 0;
             configurator.ConnectionAdded += (s, e) => connectionId = e.ConnectionId;
 
-            var connection = new PubSubConnectionDataType { Name = "C1" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "C1" };
             configurator.AddConnection(connection);
 
-            var wg1 = new WriterGroupDataType { Name = "WG1" };
+            var wg1 = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             StatusCode result1 = configurator.AddWriterGroup(connectionId, wg1);
             Assert.That(StatusCode.IsGood(result1), Is.True);
 
-            var wg2 = new WriterGroupDataType { Name = "WG1" };
+            var wg2 = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             StatusCode result2 = configurator.AddWriterGroup(connectionId, wg2);
             Assert.That(result2.Code, Is.EqualTo(StatusCodes.BadBrowseNameDuplicated));
         }
@@ -379,20 +384,20 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddReaderGroupWithDuplicateNameReturnsBadBrowseNameDuplicated()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             uint connectionId = 0;
             configurator.ConnectionAdded += (s, e) => connectionId = e.ConnectionId;
 
-            var connection = new PubSubConnectionDataType { Name = "C1" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "C1" };
             configurator.AddConnection(connection);
 
-            var rg1 = new ReaderGroupDataType { Name = "RG1" };
+            var rg1 = new ReaderGroupDataType { Enabled = true, Name = "RG1" };
             StatusCode result1 = configurator.AddReaderGroup(connectionId, rg1);
             Assert.That(StatusCode.IsGood(result1), Is.True);
 
-            var rg2 = new ReaderGroupDataType { Name = "RG1" };
+            var rg2 = new ReaderGroupDataType { Enabled = true, Name = "RG1" };
             StatusCode result2 = configurator.AddReaderGroup(connectionId, rg2);
             Assert.That(result2.Code, Is.EqualTo(StatusCodes.BadBrowseNameDuplicated));
         }
@@ -400,7 +405,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddAndRemoveWriterGroupRoundTrip()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             uint connectionId = 0;
@@ -410,8 +415,8 @@ namespace Opc.Ua.PubSub.Tests.Configuration
             bool removedFired = false;
             configurator.WriterGroupRemoved += (s, e) => removedFired = true;
 
-            configurator.AddConnection(new PubSubConnectionDataType { Name = "C1" });
-            configurator.AddWriterGroup(connectionId, new WriterGroupDataType { Name = "WG1" });
+            configurator.AddConnection(new PubSubConnectionDataType { Enabled = true, Name = "C1" });
+            configurator.AddWriterGroup(connectionId, new WriterGroupDataType { Enabled = true, Name = "WG1" });
 
             StatusCode result = configurator.RemoveWriterGroup(writerGroupId);
             Assert.That(StatusCode.IsGood(result), Is.True);
@@ -421,7 +426,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddAndRemoveReaderGroupRoundTrip()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             uint connectionId = 0;
@@ -431,8 +436,8 @@ namespace Opc.Ua.PubSub.Tests.Configuration
             bool removedFired = false;
             configurator.ReaderGroupRemoved += (s, e) => removedFired = true;
 
-            configurator.AddConnection(new PubSubConnectionDataType { Name = "C1" });
-            configurator.AddReaderGroup(connectionId, new ReaderGroupDataType { Name = "RG1" });
+            configurator.AddConnection(new PubSubConnectionDataType { Enabled = true, Name = "C1" });
+            configurator.AddReaderGroup(connectionId, new ReaderGroupDataType { Enabled = true, Name = "RG1" });
 
             StatusCode result = configurator.RemoveReaderGroup(readerGroupId);
             Assert.That(StatusCode.IsGood(result), Is.True);
@@ -442,7 +447,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddDataSetWriterToWriterGroup()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             uint connectionId = 0;
@@ -452,10 +457,10 @@ namespace Opc.Ua.PubSub.Tests.Configuration
             bool writerAddedFired = false;
             configurator.DataSetWriterAdded += (s, e) => writerAddedFired = true;
 
-            configurator.AddConnection(new PubSubConnectionDataType { Name = "C1" });
-            configurator.AddWriterGroup(connectionId, new WriterGroupDataType { Name = "WG1" });
+            configurator.AddConnection(new PubSubConnectionDataType { Enabled = true, Name = "C1" });
+            configurator.AddWriterGroup(connectionId, new WriterGroupDataType { Enabled = true, Name = "WG1" });
 
-            var writer = new DataSetWriterDataType { Name = "W1", DataSetName = "DS1" };
+            var writer = new DataSetWriterDataType { Enabled = true, Name = "W1", DataSetName = "DS1" };
             StatusCode result = configurator.AddDataSetWriter(writerGroupId, writer);
             Assert.That(StatusCode.IsGood(result), Is.True);
             Assert.That(writerAddedFired, Is.True);
@@ -464,7 +469,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddDataSetReaderToReaderGroup()
         {
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             UaPubSubConfigurator configurator = CreateConfiguratorWithConfig(config);
 
             uint connectionId = 0;
@@ -474,10 +479,10 @@ namespace Opc.Ua.PubSub.Tests.Configuration
             bool readerAddedFired = false;
             configurator.DataSetReaderAdded += (s, e) => readerAddedFired = true;
 
-            configurator.AddConnection(new PubSubConnectionDataType { Name = "C1" });
-            configurator.AddReaderGroup(connectionId, new ReaderGroupDataType { Name = "RG1" });
+            configurator.AddConnection(new PubSubConnectionDataType { Enabled = true, Name = "C1" });
+            configurator.AddReaderGroup(connectionId, new ReaderGroupDataType { Enabled = true, Name = "RG1" });
 
-            var reader = new DataSetReaderDataType { Name = "R1" };
+            var reader = new DataSetReaderDataType { Enabled = true, Name = "R1" };
             StatusCode result = configurator.AddDataSetReader(readerGroupId, reader);
             Assert.That(StatusCode.IsGood(result), Is.True);
             Assert.That(readerAddedFired, Is.True);

--- a/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPubSubConfiguratorStateTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPubSubConfiguratorStateTests.cs
@@ -110,7 +110,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void EnableUnknownObjectThrowsArgumentException()
         {
-            var connection = new PubSubConnectionDataType { Name = "Unknown" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "Unknown" };
             Assert.That(() => m_configurator.Enable(connection), Throws.TypeOf<ArgumentException>());
         }
 
@@ -120,7 +120,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void DisableUnknownObjectThrowsArgumentException()
         {
-            var connection = new PubSubConnectionDataType { Name = "Unknown" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "Unknown" };
             Assert.That(() => m_configurator.Disable(connection), Throws.TypeOf<ArgumentException>());
         }
 
@@ -264,7 +264,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void FindStateForObjectReturnsErrorForUnknownObject()
         {
-            var unknown = new PubSubConnectionDataType { Name = "Unknown" };
+            var unknown = new PubSubConnectionDataType { Enabled = true, Name = "Unknown" };
             PubSubState state = m_configurator.FindStateForObject(unknown);
             Assert.That(state, Is.EqualTo(PubSubState.Error));
         }
@@ -295,7 +295,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void FindIdForObjectReturnsInvalidIdForUnknownObject()
         {
-            uint id = m_configurator.FindIdForObject(new PubSubConnectionDataType());
+            uint id = m_configurator.FindIdForObject(new PubSubConnectionDataType { Enabled = true });
             Assert.That(id, Is.EqualTo(UaPubSubConfigurator.InvalidId));
         }
 
@@ -494,6 +494,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
 
             var newConfig = new PubSubConfigurationDataType
             {
+                Enabled = true,
                 Connections = [],
                 PublishedDataSets = []
             };
@@ -514,6 +515,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         {
             var config = new PubSubConfigurationDataType
             {
+                Enabled = true,
                 Connections = [],
                 PublishedDataSets = []
             };

--- a/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPubSubConfiguratorTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPubSubConfiguratorTests.cs
@@ -83,7 +83,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void FindObjectByIdReturnsObjectWhenFound()
         {
-            var connection = new PubSubConnectionDataType { Name = "Conn1" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "Conn1" };
             StatusCode result = m_configurator.AddConnection(connection);
             Assert.That(StatusCode.IsGood(result), Is.True);
 
@@ -104,14 +104,14 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void FindIdForObjectReturnsInvalidIdForUnknownObject()
         {
-            uint id = m_configurator.FindIdForObject(new PubSubConnectionDataType());
+            uint id = m_configurator.FindIdForObject(new PubSubConnectionDataType { Enabled = true });
             Assert.That(id, Is.EqualTo(UaPubSubConfigurator.InvalidId));
         }
 
         [Test]
         public void FindStateForObjectReturnsOperationalForNewConnection()
         {
-            var connection = new PubSubConnectionDataType { Name = "StateConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "StateConn" };
             m_configurator.AddConnection(connection);
 
             PubSubState state = m_configurator.FindStateForObject(connection);
@@ -121,14 +121,14 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void FindStateForObjectReturnsErrorForUnknownObject()
         {
-            PubSubState state = m_configurator.FindStateForObject(new PubSubConnectionDataType());
+            PubSubState state = m_configurator.FindStateForObject(new PubSubConnectionDataType { Enabled = true });
             Assert.That(state, Is.EqualTo(PubSubState.Error));
         }
 
         [Test]
         public void FindStateForIdReturnsOperationalForNewConnection()
         {
-            var connection = new PubSubConnectionDataType { Name = "StateIdConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "StateIdConn" };
             m_configurator.AddConnection(connection);
 
             uint id = m_configurator.FindIdForObject(connection);
@@ -146,18 +146,18 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void FindParentForObjectReturnsNullForUnknownObject()
         {
-            object parent = m_configurator.FindParentForObject(new PubSubConnectionDataType());
+            object parent = m_configurator.FindParentForObject(new PubSubConnectionDataType { Enabled = true });
             Assert.That(parent, Is.Null);
         }
 
         [Test]
         public void FindParentForObjectReturnsParentForWriterGroup()
         {
-            var connection = new PubSubConnectionDataType { Name = "ParentConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "ParentConn" };
             m_configurator.AddConnection(connection);
             uint connId = m_configurator.FindIdForObject(connection);
 
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             StatusCode result = m_configurator.AddWriterGroup(connId, writerGroup);
             Assert.That(StatusCode.IsGood(result), Is.True);
 
@@ -169,21 +169,21 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         public void FindChildrenIdsForObjectReturnsEmptyForUnknownObject()
         {
             List<uint> children = m_configurator.FindChildrenIdsForObject(
-                new PubSubConnectionDataType());
+                new PubSubConnectionDataType { Enabled = true });
             Assert.That(children, Is.Empty);
         }
 
         [Test]
         public void FindChildrenIdsForObjectReturnsChildrenForConnection()
         {
-            var connection = new PubSubConnectionDataType { Name = "ChildConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "ChildConn" };
             m_configurator.AddConnection(connection);
             uint connId = m_configurator.FindIdForObject(connection);
 
-            var writerGroup = new WriterGroupDataType { Name = "ChildWG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "ChildWG1" };
             m_configurator.AddWriterGroup(connId, writerGroup);
 
-            var readerGroup = new ReaderGroupDataType { Name = "ChildRG1" };
+            var readerGroup = new ReaderGroupDataType { Enabled = true, Name = "ChildRG1" };
             m_configurator.AddReaderGroup(connId, readerGroup);
 
             List<uint> children = m_configurator.FindChildrenIdsForObject(connection);
@@ -193,7 +193,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void EnableConnectionFromDisabledChangesStateToOperational()
         {
-            var connection = new PubSubConnectionDataType { Name = "EnableConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "EnableConn" };
             m_configurator.AddConnection(connection);
 
             // Connections start Operational, so disable first
@@ -211,7 +211,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void EnableByIdFromDisabledChangesState()
         {
-            var connection = new PubSubConnectionDataType { Name = "EnableIdConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "EnableIdConn" };
             m_configurator.AddConnection(connection);
             uint connId = m_configurator.FindIdForObject(connection);
 
@@ -223,7 +223,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void EnableAlreadyOperationalReturnsBadInvalidState()
         {
-            var connection = new PubSubConnectionDataType { Name = "DoubleEnableConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "DoubleEnableConn" };
             m_configurator.AddConnection(connection);
 
             // Connections start Operational
@@ -241,13 +241,13 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         public void EnableUnknownObjectThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(
-                () => m_configurator.Enable(new PubSubConnectionDataType()));
+                () => m_configurator.Enable(new PubSubConnectionDataType { Enabled = true }));
         }
 
         [Test]
         public void DisableConnectionChangesStateToDisabled()
         {
-            var connection = new PubSubConnectionDataType { Name = "DisableConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "DisableConn" };
             m_configurator.AddConnection(connection);
             // Connection starts Operational
 
@@ -261,7 +261,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void DisableByIdChangesState()
         {
-            var connection = new PubSubConnectionDataType { Name = "DisableIdConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "DisableIdConn" };
             m_configurator.AddConnection(connection);
             uint connId = m_configurator.FindIdForObject(connection);
             // Connection starts Operational
@@ -273,7 +273,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void DisableAlreadyDisabledReturnsBadInvalidState()
         {
-            var connection = new PubSubConnectionDataType { Name = "DoubleDisableConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "DoubleDisableConn" };
             m_configurator.AddConnection(connection);
 
             // Disable first time (from Operational)
@@ -293,17 +293,17 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         public void DisableUnknownObjectThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(
-                () => m_configurator.Disable(new PubSubConnectionDataType()));
+                () => m_configurator.Disable(new PubSubConnectionDataType { Enabled = true }));
         }
 
         [Test]
         public void EnableDisableWithChildrenPropagatesState()
         {
-            var connection = new PubSubConnectionDataType { Name = "PropConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "PropConn" };
             m_configurator.AddConnection(connection);
             uint connId = m_configurator.FindIdForObject(connection);
 
-            var writerGroup = new WriterGroupDataType { Name = "PropWG" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "PropWG" };
             m_configurator.AddWriterGroup(connId, writerGroup);
 
             // Connection starts Operational, children should also be Operational
@@ -370,7 +370,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void LoadConfigurationWithReplaceExistingClearsOldData()
         {
-            var connection = new PubSubConnectionDataType { Name = "OldConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "OldConn" };
             m_configurator.AddConnection(connection);
 
             string configFile = Utils.GetAbsoluteFilePath(
@@ -403,7 +403,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void FindChildrenIdsForConnectionWithNoChildren()
         {
-            var connection = new PubSubConnectionDataType { Name = "NoChildConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "NoChildConn" };
             m_configurator.AddConnection(connection);
 
             List<uint> children = m_configurator.FindChildrenIdsForObject(connection);
@@ -413,11 +413,11 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddAndRemoveWriterGroupUpdatesLookups()
         {
-            var connection = new PubSubConnectionDataType { Name = "WGConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "WGConn" };
             m_configurator.AddConnection(connection);
             uint connId = m_configurator.FindIdForObject(connection);
 
-            var writerGroup = new WriterGroupDataType { Name = "TestWG" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "TestWG" };
             StatusCode addResult = m_configurator.AddWriterGroup(connId, writerGroup);
             Assert.That(StatusCode.IsGood(addResult), Is.True);
 
@@ -434,11 +434,11 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddAndRemoveReaderGroupUpdatesLookups()
         {
-            var connection = new PubSubConnectionDataType { Name = "RGConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "RGConn" };
             m_configurator.AddConnection(connection);
             uint connId = m_configurator.FindIdForObject(connection);
 
-            var readerGroup = new ReaderGroupDataType { Name = "TestRG" };
+            var readerGroup = new ReaderGroupDataType { Enabled = true, Name = "TestRG" };
             StatusCode addResult = m_configurator.AddReaderGroup(connId, readerGroup);
             Assert.That(StatusCode.IsGood(addResult), Is.True);
 
@@ -452,15 +452,15 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddAndRemoveDataSetWriterUpdatesLookups()
         {
-            var connection = new PubSubConnectionDataType { Name = "DSWConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "DSWConn" };
             m_configurator.AddConnection(connection);
             uint connId = m_configurator.FindIdForObject(connection);
 
-            var writerGroup = new WriterGroupDataType { Name = "DSWWG" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "DSWWG" };
             m_configurator.AddWriterGroup(connId, writerGroup);
             uint wgId = m_configurator.FindIdForObject(writerGroup);
 
-            var dataSetWriter = new DataSetWriterDataType { Name = "TestDSW" };
+            var dataSetWriter = new DataSetWriterDataType { Enabled = true, Name = "TestDSW" };
             StatusCode addResult = m_configurator.AddDataSetWriter(wgId, dataSetWriter);
             Assert.That(StatusCode.IsGood(addResult), Is.True);
 
@@ -474,15 +474,15 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void AddAndRemoveDataSetReaderUpdatesLookups()
         {
-            var connection = new PubSubConnectionDataType { Name = "DSRConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "DSRConn" };
             m_configurator.AddConnection(connection);
             uint connId = m_configurator.FindIdForObject(connection);
 
-            var readerGroup = new ReaderGroupDataType { Name = "DSRRG" };
+            var readerGroup = new ReaderGroupDataType { Enabled = true, Name = "DSRRG" };
             m_configurator.AddReaderGroup(connId, readerGroup);
             uint rgId = m_configurator.FindIdForObject(readerGroup);
 
-            var dataSetReader = new DataSetReaderDataType { Name = "TestDSR" };
+            var dataSetReader = new DataSetReaderDataType { Enabled = true, Name = "TestDSR" };
             StatusCode addResult = m_configurator.AddDataSetReader(rgId, dataSetReader);
             Assert.That(StatusCode.IsGood(addResult), Is.True);
 
@@ -496,14 +496,14 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void EnableWriterGroupFromDisabledWithDisabledParentSetsPausedState()
         {
-            var connection = new PubSubConnectionDataType { Name = "PausedParentConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "PausedParentConn" };
             m_configurator.AddConnection(connection);
             uint connId = m_configurator.FindIdForObject(connection);
 
             // Disable parent first
             m_configurator.Disable(connection);
 
-            var writerGroup = new WriterGroupDataType { Name = "PausedWG" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "PausedWG" };
             m_configurator.AddWriterGroup(connId, writerGroup);
 
             // Writer group should start disabled since parent is disabled
@@ -518,12 +518,12 @@ namespace Opc.Ua.PubSub.Tests.Configuration
         [Test]
         public void EnableWriterGroupFromDisabledWithOperationalParentSetsOperationalState()
         {
-            var connection = new PubSubConnectionDataType { Name = "OpParentConn" };
+            var connection = new PubSubConnectionDataType { Enabled = true, Name = "OpParentConn" };
             m_configurator.AddConnection(connection);
             uint connId = m_configurator.FindIdForObject(connection);
             // Connection starts Operational
 
-            var writerGroup = new WriterGroupDataType { Name = "OpWG" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "OpWG" };
             m_configurator.AddWriterGroup(connId, writerGroup);
 
             // Disable the writer group, then re-enable

--- a/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPublisherTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Configuration/UaPublisherTests.cs
@@ -76,6 +76,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
 
             var writerGroupDataType = new WriterGroupDataType
             {
+                Enabled = true,
                 PublishingInterval = publishingInterval
             };
 
@@ -125,6 +126,7 @@ namespace Opc.Ua.PubSub.Tests.Configuration
 
             var writerGroupDataType = new WriterGroupDataType
             {
+                Enabled = true,
                 PublishingInterval = publishingInterval
             };
 

--- a/Tests/Opc.Ua.PubSub.Tests/DataSetDecodeErrorEventArgsTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/DataSetDecodeErrorEventArgsTests.cs
@@ -84,6 +84,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         {
             var reader = new DataSetReaderDataType
             {
+                Enabled = true,
                 Name = "TestReader",
                 DataSetWriterId = 1
             };
@@ -101,7 +102,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         public void ConstructorSetsAllProperties()
         {
             var networkMessage = new PubSubEncoding.JsonNetworkMessage();
-            var reader = new DataSetReaderDataType { Name = "Reader1" };
+            var reader = new DataSetReaderDataType { Enabled = true, Name = "Reader1" };
 
             var args = new DataSetDecodeErrorEventArgs(
                 DataSetDecodeErrorReason.MetadataMajorVersion,
@@ -169,7 +170,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
                 null,
                 null);
 
-            var reader = new DataSetReaderDataType { Name = "NewReader" };
+            var reader = new DataSetReaderDataType { Enabled = true, Name = "NewReader" };
             args.DataSetReader = reader;
             Assert.That(args.DataSetReader, Is.SameAs(reader));
             Assert.That(args.DataSetReader.Name, Is.EqualTo("NewReader"));

--- a/Tests/Opc.Ua.PubSub.Tests/Encoding/JsonDataSetMessageAdditionalTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Encoding/JsonDataSetMessageAdditionalTests.cs
@@ -422,6 +422,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         {
             return new DataSetReaderDataType
             {
+                Enabled = true,
                 Name = "Reader1",
                 DataSetMetaData = new DataSetMetaDataType
                 {

--- a/Tests/Opc.Ua.PubSub.Tests/Encoding/JsonNetworkMessageTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Encoding/JsonNetworkMessageTests.cs
@@ -79,6 +79,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
 
             var writerGroup = new WriterGroupDataType
             {
+                Enabled = true,
                 Name = "WG1",
                 MessageSettings = new ExtensionObject(
                     new JsonWriterGroupMessageDataType
@@ -104,6 +105,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         {
             return new DataSetReaderDataType
             {
+                Enabled = true,
                 Name = "Reader1",
                 PublisherId = publisherId != null ? Variant.From(publisherId) : Variant.Null,
                 DataSetFieldContentMask = (uint)DataSetFieldContentMask.None,
@@ -184,7 +186,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         [Test]
         public void EncodeDecodeMetaDataMessageRoundTrips()
         {
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var metadata = new DataSetMetaDataType
             {
                 Name = "MetaRoundTrip",
@@ -211,7 +213,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         [Test]
         public void EncodeMetaDataWithoutDataSetWriterIdLogsButDoesNotThrow()
         {
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var metadata = new DataSetMetaDataType { Name = "Meta1" };
             var msg = new PubSubEncoding.JsonNetworkMessage(writerGroup, metadata, null)
             {
@@ -295,7 +297,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
             var dsMsg2 = new PubSubEncoding.JsonDataSetMessage(dataSet2, null);
             dsMsg2.SetFieldContentMask(DataSetFieldContentMask.None);
 
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var msg = new PubSubEncoding.JsonNetworkMessage(
                 writerGroup, [dsMsg1, dsMsg2], null);
             msg.SetNetworkMessageContentMask(JsonNetworkMessageContentMask.None);
@@ -331,7 +333,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
             var dsMsg2 = new PubSubEncoding.JsonDataSetMessage(dataSet1, null);
             dsMsg2.SetFieldContentMask(DataSetFieldContentMask.None);
 
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var msg = new PubSubEncoding.JsonNetworkMessage(
                 writerGroup, [dsMsg1, dsMsg2], null);
             msg.SetNetworkMessageContentMask(
@@ -402,7 +404,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
                 }
             };
 
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var dsMsg = new PubSubEncoding.JsonDataSetMessage(dataSet, null);
             dsMsg.SetFieldContentMask(DataSetFieldContentMask.None);
 
@@ -521,6 +523,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
 
             var reader = new DataSetReaderDataType
             {
+                Enabled = true,
                 Name = "BadReader",
                 PublisherId = Variant.Null,
                 DataSetFieldContentMask = (uint)DataSetFieldContentMask.None,
@@ -596,7 +599,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
                 }
             };
 
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var dsMsg = new PubSubEncoding.JsonDataSetMessage(dataSet, null);
             dsMsg.SetFieldContentMask(DataSetFieldContentMask.None);
 
@@ -616,7 +619,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         [Test]
         public void DecodeMetaDataMessageSetsMetaData()
         {
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var metadata = new DataSetMetaDataType
             {
                 Name = "MetaDecode",
@@ -643,7 +646,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         [Test]
         public void DecodeMetaDataMessageViaSubscribedDataSetsPath()
         {
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var metadata = new DataSetMetaDataType
             {
                 Name = "MetaViaSubscribed",
@@ -671,7 +674,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         [Test]
         public void EncodeEmptyDataSetMessagesWithHeaderProducesValidJson()
         {
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var msg = new PubSubEncoding.JsonNetworkMessage(
                 writerGroup, new List<PubSubEncoding.JsonDataSetMessage>(), null);
             msg.SetNetworkMessageContentMask(
@@ -708,7 +711,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
                 }
             };
 
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var dsMsg = new PubSubEncoding.JsonDataSetMessage(dataSet, null);
             dsMsg.SetFieldContentMask(DataSetFieldContentMask.None);
 

--- a/Tests/Opc.Ua.PubSub.Tests/Encoding/MessagesHelper.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Encoding/MessagesHelper.cs
@@ -342,6 +342,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
             //create  the PubSub configuration root object
             var pubSubConfiguration = new PubSubConfigurationDataType
             {
+                Enabled = true,
                 Connections = [pubSubConnection1],
                 PublishedDataSets = []
             };
@@ -665,6 +666,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
             //create  the PubSub configuration root object
             var pubSubConfiguration = new PubSubConfigurationDataType
             {
+                Enabled = true,
                 Connections = [pubSubConnection]
             };
 
@@ -1018,7 +1020,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
             pubSubConnection1.ReaderGroups = pubSubConnection1.ReaderGroups.AddItem(readerGroup1);
 
             //create  the PubSub configuration root object
-            return new PubSubConfigurationDataType { Connections = [pubSubConnection1] };
+            return new PubSubConfigurationDataType { Enabled = true, Connections = [pubSubConnection1] };
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.PubSub.Tests/Encoding/MqttJsonNetworkMessageAdditionalTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Encoding/MqttJsonNetworkMessageAdditionalTests.cs
@@ -77,6 +77,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
 
             var writerGroup = new WriterGroupDataType
             {
+                Enabled = true,
                 Name = "WG1",
                 MessageSettings = new ExtensionObject(
                     new JsonWriterGroupMessageDataType
@@ -108,7 +109,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         [Test]
         public void ConstructorWithWriterGroupAndMessagesCreatesDataSetMessage()
         {
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var messages = new List<PubSubEncoding.JsonDataSetMessage>();
             var msg = new PubSubEncoding.JsonNetworkMessage(writerGroup, messages, null);
             Assert.That(msg.MessageType, Is.EqualTo("ua-data"));
@@ -117,7 +118,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         [Test]
         public void ConstructorWithMetaDataCreatesMetaDataMessage()
         {
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var metadata = new DataSetMetaDataType { Name = "TestMeta" };
             var msg = new PubSubEncoding.JsonNetworkMessage(writerGroup, metadata, null);
             Assert.That(msg.MessageType, Is.EqualTo("ua-metadata"));
@@ -187,6 +188,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
 
             var reader = new DataSetReaderDataType
             {
+                Enabled = true,
                 Name = "Reader1",
                 PublisherId = Variant.Null,
                 DataSetFieldContentMask = (uint)DataSetFieldContentMask.None,
@@ -255,7 +257,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
             var dsMsg1 = new PubSubEncoding.JsonDataSetMessage(dataSet1, null);
             dsMsg1.SetFieldContentMask(DataSetFieldContentMask.None);
 
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var msg = new PubSubEncoding.JsonNetworkMessage(
                 writerGroup,
                 [dsMsg1],
@@ -270,7 +272,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         [Test]
         public void EncodeMetaDataMessageProducesBytes()
         {
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var metadata = new DataSetMetaDataType
             {
                 Name = "MetaTest",
@@ -375,6 +377,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
 
             var reader = new DataSetReaderDataType
             {
+                Enabled = true,
                 Name = "Reader1",
                 PublisherId = Variant.From("WrongPublisher"),
                 DataSetFieldContentMask = (uint)DataSetFieldContentMask.None,

--- a/Tests/Opc.Ua.PubSub.Tests/Encoding/PubSubJsonDecoderAdditionalTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Encoding/PubSubJsonDecoderAdditionalTests.cs
@@ -72,6 +72,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
 
             var reader = new DataSetReaderDataType
             {
+                Enabled = true,
                 Name = "Reader1",
                 PublisherId = new Variant("TestPub"),
                 DataSetWriterId = 0,
@@ -509,6 +510,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
 
             var reader = new DataSetReaderDataType
             {
+                Enabled = true,
                 Name = "RTReader",
                 PublisherId = new Variant("RTPub"),
                 DataSetWriterId = 0,
@@ -559,6 +561,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
 
             var reader = new DataSetReaderDataType
             {
+                Enabled = true,
                 Name = "NullPubReader",
                 PublisherId = Variant.Null,
                 DataSetWriterId = 0,
@@ -609,6 +612,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
 
             var reader = new DataSetReaderDataType
             {
+                Enabled = true,
                 Name = "MismatchReader",
                 PublisherId = new Variant("PubB"),
                 DataSetWriterId = 0,

--- a/Tests/Opc.Ua.PubSub.Tests/Encoding/PubSubJsonDecoderFinalTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Encoding/PubSubJsonDecoderFinalTests.cs
@@ -1836,6 +1836,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
 
             var reader = new DataSetReaderDataType
             {
+                Enabled = true,
                 Name = "TestReader",
                 DataSetWriterId = dataSetWriterId,
                 DataSetFieldContentMask = (uint)fieldContentMask,

--- a/Tests/Opc.Ua.PubSub.Tests/Encoding/PubSubJsonEncoderAdditionalTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Encoding/PubSubJsonEncoderAdditionalTests.cs
@@ -1047,7 +1047,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         {
             using var encoder = new PubSubJsonEncoder(m_context, useReversibleEncoding: true);
             encoder.PushStructure(null);
-            var extObj = new ExtensionObject(new WriterGroupDataType { Name = "TestWG" });
+            var extObj = new ExtensionObject(new WriterGroupDataType { Enabled = true, Name = "TestWG" });
             encoder.WriteExtensionObject("ExtObj", extObj);
             encoder.PopStructure();
 

--- a/Tests/Opc.Ua.PubSub.Tests/Encoding/UadpDataSetMessageAdditionalTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Encoding/UadpDataSetMessageAdditionalTests.cs
@@ -436,6 +436,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
 
             var reader = new DataSetReaderDataType
             {
+                Enabled = true,
                 DataSetMetaData = metaData,
                 MessageSettings = new ExtensionObject(
                     new UadpDataSetReaderMessageDataType())

--- a/Tests/Opc.Ua.PubSub.Tests/Encoding/UadpNetworkMessageAdditionalTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Encoding/UadpNetworkMessageAdditionalTests.cs
@@ -519,6 +519,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         {
             return new WriterGroupDataType
             {
+                Enabled = true,
                 WriterGroupId = 1,
                 MessageSettings = new ExtensionObject(
                     new UadpWriterGroupMessageDataType
@@ -581,6 +582,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
 
             var reader = new DataSetReaderDataType
             {
+                Enabled = true,
                 DataSetWriterId = dataSetMessage.DataSetWriterId,
                 WriterGroupId = 1,
                 DataSetMetaData = metaData,

--- a/Tests/Opc.Ua.PubSub.Tests/PublishedData/WriterGroupPublishedStateTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/PublishedData/WriterGroupPublishedStateTests.cs
@@ -433,6 +433,7 @@ namespace Opc.Ua.PubSub.Tests.PublishedData
             // Arrange - create a simple DataSetWriter with specified KeyFrameCount
             var writer = new DataSetWriterDataType
             {
+                Enabled = true,
                 DataSetWriterId = 1,
                 KeyFrameCount = (uint)keyFrameCount
             };

--- a/Tests/Opc.Ua.PubSub.Tests/Transport/MqttPubSubConnectionTests.Mqtts.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Transport/MqttPubSubConnectionTests.Mqtts.cs
@@ -71,6 +71,7 @@ namespace Opc.Ua.PubSub.Tests.Transport
             using var uaPubSubApplication = UaPubSubApplication.Create(telemetry);
             var pubSubConnectionDataType = new PubSubConnectionDataType
             {
+                Enabled = true,
                 Address = new ExtensionObject(new NetworkAddressUrlDataType { Url = "mqtts://localhost:8883" }),
                 ConnectionProperties = mqttConfiguration.ConnectionProperties
             };

--- a/Tests/Opc.Ua.PubSub.Tests/Transport/UdpPubSubConnectionAdditionalTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Transport/UdpPubSubConnectionAdditionalTests.cs
@@ -112,6 +112,7 @@ namespace Opc.Ua.PubSub.Tests.Transport
         {
             var writerGroup = new WriterGroupDataType
             {
+                Enabled = true,
                 Name = "InvalidWG",
                 MessageSettings = default,
                 TransportSettings = default
@@ -127,6 +128,7 @@ namespace Opc.Ua.PubSub.Tests.Transport
         {
             var writerGroup = new WriterGroupDataType
             {
+                Enabled = true,
                 Name = "WrongSettingsWG",
                 MessageSettings = new ExtensionObject(new JsonWriterGroupMessageDataType()),
                 TransportSettings = new ExtensionObject(new DatagramWriterGroupTransportDataType())
@@ -142,6 +144,7 @@ namespace Opc.Ua.PubSub.Tests.Transport
         {
             var writerGroup = new WriterGroupDataType
             {
+                Enabled = true,
                 Name = "WrongTransportWG",
                 MessageSettings = new ExtensionObject(new UadpWriterGroupMessageDataType()),
                 TransportSettings = new ExtensionObject(new BrokerWriterGroupTransportDataType())
@@ -157,6 +160,7 @@ namespace Opc.Ua.PubSub.Tests.Transport
         {
             var writerGroup = new WriterGroupDataType
             {
+                Enabled = true,
                 Name = "EmptyWritersWG",
                 MessageSettings = new ExtensionObject(new UadpWriterGroupMessageDataType()),
                 TransportSettings = new ExtensionObject(new DatagramWriterGroupTransportDataType()),

--- a/Tests/Opc.Ua.PubSub.Tests/UaNetworkMessageTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/UaNetworkMessageTests.cs
@@ -54,7 +54,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         [Test]
         public void DataSetMessagesConstructorSetsProperties()
         {
-            var writerGroup = new WriterGroupDataType { Name = "WG1", WriterGroupId = 5 };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1", WriterGroupId = 5 };
             var messages = new List<PubSubEncoding.JsonDataSetMessage>();
 
             var msg = new PubSubEncoding.JsonNetworkMessage(writerGroup, messages);
@@ -68,7 +68,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         [Test]
         public void MetaDataConstructorSetsProperties()
         {
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var metadata = new DataSetMetaDataType { Name = "Meta1" };
 
             var msg = new PubSubEncoding.JsonNetworkMessage(writerGroup, metadata);
@@ -111,7 +111,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         public void DataSetWriterIdReturnsSingleMessageWriterIdWhenUnset()
         {
             var dsMessage = new PubSubEncoding.JsonDataSetMessage { DataSetWriterId = 77 };
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var msg = new PubSubEncoding.JsonNetworkMessage(writerGroup, [dsMessage]);
 
             Assert.That(msg.DataSetWriterId, Is.EqualTo(77));
@@ -122,7 +122,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         {
             var dsMessage1 = new PubSubEncoding.JsonDataSetMessage { DataSetWriterId = 10 };
             var dsMessage2 = new PubSubEncoding.JsonDataSetMessage { DataSetWriterId = 20 };
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var msg = new PubSubEncoding.JsonNetworkMessage(
                 writerGroup, [dsMessage1, dsMessage2]);
 
@@ -189,7 +189,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
         [Test]
         public void DataSetMessagesConstructorWithNullListCreatesEmptyMessages()
         {
-            var writerGroup = new WriterGroupDataType { Name = "WG1" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "WG1" };
             var msg = new PubSubEncoding.JsonNetworkMessage(
                 writerGroup, (List<PubSubEncoding.JsonDataSetMessage>)null);
             Assert.That(msg.DataSetMessages, Is.Not.Null);

--- a/Tests/Opc.Ua.PubSub.Tests/UaPubSubApplicationTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/UaPubSubApplicationTests.cs
@@ -75,7 +75,7 @@ namespace Opc.Ua.PubSub.Tests
         public void CreateWithEmptyConfigReturnsEmptyConnections()
         {
             ITelemetryContext telemetry = NUnitTelemetryContext.Create();
-            var config = new PubSubConfigurationDataType();
+            var config = new PubSubConfigurationDataType { Enabled = true };
             using UaPubSubApplication app = UaPubSubApplication.Create(config, telemetry);
             Assert.That(app, Is.Not.Null);
             Assert.That(app.PubSubConnections.Count, Is.Zero);

--- a/Tests/Opc.Ua.PubSub.Tests/UaPubSubConnectionTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/UaPubSubConnectionTests.cs
@@ -129,14 +129,14 @@ namespace Opc.Ua.PubSub.Tests.Transport
         public void CanPublishReturnsFalseWhenNotRunning()
         {
             Assert.That(m_connection.IsRunning, Is.False);
-            var writerGroup = new WriterGroupDataType();
+            var writerGroup = new WriterGroupDataType { Enabled = true };
             Assert.That(m_connection.CanPublish(writerGroup), Is.False);
         }
 
         [Test]
         public void CanPublishReturnsFalseForNullWriterGroup()
         {
-            var writerGroup = new WriterGroupDataType { Name = "NonExistent" };
+            var writerGroup = new WriterGroupDataType { Enabled = true, Name = "NonExistent" };
             Assert.That(m_connection.CanPublish(writerGroup), Is.False);
         }
 
@@ -231,6 +231,7 @@ namespace Opc.Ua.PubSub.Tests.Transport
 
             var pubSubConfig = new PubSubConfigurationDataType
             {
+                Enabled = true,
                 Connections = [connectionConfig]
             };
 

--- a/Tests/Opc.Ua.PubSub.Tests/WriterGroupPublishStateTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/WriterGroupPublishStateTests.cs
@@ -46,7 +46,7 @@ namespace Opc.Ua.PubSub.Tests
         public void HasMetaDataChangedReturnsFalseForNullMetadata()
         {
             var state = new WriterGroupPublishState();
-            var writer = new DataSetWriterDataType { DataSetWriterId = 1 };
+            var writer = new DataSetWriterDataType { Enabled = true, DataSetWriterId = 1 };
 
             bool result = state.HasMetaDataChanged(writer, null);
 
@@ -60,7 +60,7 @@ namespace Opc.Ua.PubSub.Tests
         public void ExcludeUnchangedFieldsReturnsDataSetOnFirstCall()
         {
             var state = new WriterGroupPublishState();
-            var writer = new DataSetWriterDataType { DataSetWriterId = 1 };
+            var writer = new DataSetWriterDataType { Enabled = true, DataSetWriterId = 1 };
 
             var dataset = new DataSet("Test")
             {
@@ -84,7 +84,7 @@ namespace Opc.Ua.PubSub.Tests
         public void ExcludeUnchangedFieldsReturnsNullWhenNoChange()
         {
             var state = new WriterGroupPublishState();
-            var writer = new DataSetWriterDataType { DataSetWriterId = 1 };
+            var writer = new DataSetWriterDataType { Enabled = true, DataSetWriterId = 1 };
 
             var dataset1 = new DataSet("Test")
             {
@@ -118,7 +118,7 @@ namespace Opc.Ua.PubSub.Tests
         public void ExcludeUnchangedFieldsDetectsValueChange()
         {
             var state = new WriterGroupPublishState();
-            var writer = new DataSetWriterDataType { DataSetWriterId = 1 };
+            var writer = new DataSetWriterDataType { Enabled = true, DataSetWriterId = 1 };
 
             var dataset1 = new DataSet("Test")
             {
@@ -154,7 +154,7 @@ namespace Opc.Ua.PubSub.Tests
         public void ExcludeUnchangedFieldsDetectsStatusCodeChange()
         {
             var state = new WriterGroupPublishState();
-            var writer = new DataSetWriterDataType { DataSetWriterId = 1 };
+            var writer = new DataSetWriterDataType { Enabled = true, DataSetWriterId = 1 };
 
             var dataset1 = new DataSet("Test")
             {
@@ -186,7 +186,7 @@ namespace Opc.Ua.PubSub.Tests
         public void ExcludeUnchangedFieldsHandlesNullFieldInSecondDataSet()
         {
             var state = new WriterGroupPublishState();
-            var writer = new DataSetWriterDataType { DataSetWriterId = 1 };
+            var writer = new DataSetWriterDataType { Enabled = true, DataSetWriterId = 1 };
 
             var dataset1 = new DataSet("Test")
             {
@@ -220,7 +220,7 @@ namespace Opc.Ua.PubSub.Tests
         public void ExcludeUnchangedFieldsHandlesNullFieldInLastDataSet()
         {
             var state = new WriterGroupPublishState();
-            var writer = new DataSetWriterDataType { DataSetWriterId = 1 };
+            var writer = new DataSetWriterDataType { Enabled = true, DataSetWriterId = 1 };
 
             var dataset1 = new DataSet("Test")
             {

--- a/Tests/Opc.Ua.SourceGeneration.Core.Tests/Schema/ModelDesignExtensionsTests.cs
+++ b/Tests/Opc.Ua.SourceGeneration.Core.Tests/Schema/ModelDesignExtensionsTests.cs
@@ -661,10 +661,10 @@ namespace Opc.Ua.Schema.Model.Tests
         }
 
         /// <summary>
-        /// Tests GetDefaultDotNetValue with Boolean type and true value without defaultValue (inverted bug).
+        /// Tests GetDefaultDotNetValue with Boolean type and true value without defaultValue.
         /// </summary>
-        [Theory]
-        public void GetDefaultDotNetValue_BooleanTrueWithoutDefaultValue_ReturnsFalseWithQuirk(bool quirk)
+        [Test]
+        public void GetDefaultDotNetValue_BooleanTrueWithoutDefaultValue_ReturnsTrue()
         {
             // Arrange
             var mockDataType = new DataTypeDesign
@@ -682,19 +682,18 @@ namespace Opc.Ua.Schema.Model.Tests
                 false,
                 "TestNamespace",
                 namespaces,
-                mockContext.Object,
-                dataTypeQuirk: quirk);
+                mockContext.Object);
 
             // Assert
-            Assert.That(result, Is.EqualTo(quirk ? "false" : "true"));
+            Assert.That(result, Is.EqualTo("true"));
         }
 
         /// <summary>
-        /// Tests GetDefaultDotNetValue with Boolean type and false value without defaultValue (inverted bug).
-        /// Expected: Returns "true" due to documented bug.
+        /// Tests GetDefaultDotNetValue with Boolean type and false value without defaultValue.
+        /// Expected: Returns "false".
         /// </summary>
-        [Theory]
-        public void GetDefaultDotNetValue_BooleanFalseWithoutDefaultValue_ReturnsTrueWhenQuirk(bool quirk)
+        [Test]
+        public void GetDefaultDotNetValue_BooleanFalseWithoutDefaultValue_ReturnsFalse()
         {
             // Arrange
             var mockDataType = new DataTypeDesign
@@ -712,11 +711,10 @@ namespace Opc.Ua.Schema.Model.Tests
                 false,
                 "TestNamespace",
                 namespaces,
-                mockContext.Object,
-                dataTypeQuirk: quirk);
+                mockContext.Object);
 
             // Assert
-            Assert.That(result, Is.EqualTo(quirk ? "true" : "false"));
+            Assert.That(result, Is.EqualTo("false"));
         }
 
         /// <summary>

--- a/Tools/Opc.Ua.SourceGeneration.Core/Generators/DataTypeGenerator.cs
+++ b/Tools/Opc.Ua.SourceGeneration.Core/Generators/DataTypeGenerator.cs
@@ -1152,8 +1152,7 @@ namespace Opc.Ua.SourceGeneration
                     field,
                     field.ValueRank,
                     field.DataTypeNode,
-                    field.DefaultValue),
-                dataTypeQuirk: true);
+                    field.DefaultValue));
 
             context.Out.WriteLine("{0} = {1};", field.GetChildFieldName(), value);
             return null;
@@ -1239,8 +1238,7 @@ namespace Opc.Ua.SourceGeneration
                         field,
                         field.ValueRank,
                         field.DataTypeNode,
-                        field.DefaultValue),
-                    dataTypeQuirk: true));
+                        field.DefaultValue)));
             context.Template.AddReplacement(
                 Tokens.Identifier,
                 field.Identifier.ToString(CultureInfo.InvariantCulture));

--- a/Tools/Opc.Ua.SourceGeneration.Core/Schema/ModelDesignExtensions.cs
+++ b/Tools/Opc.Ua.SourceGeneration.Core/Schema/ModelDesignExtensions.cs
@@ -776,8 +776,7 @@ namespace Opc.Ua.Schema.Model
             string targetNamespace,
             Namespace[] namespaces,
             IServiceMessageContext context,
-            Func<string> onUnknownElement = null,
-            bool dataTypeQuirk = false)
+            Func<string> onUnknownElement = null)
         {
             TypeInfo decodedValueType = default;
             string defaultString = valueAsVariant ?
@@ -818,8 +817,7 @@ namespace Opc.Ua.Schema.Model
                     valueAsVariant,
                     targetNamespace,
                     namespaces,
-                    onUnknownElement,
-                    dataTypeQuirk)
+                    onUnknownElement)
                     ?? defaultString;
             }
 
@@ -837,8 +835,7 @@ namespace Opc.Ua.Schema.Model
             bool valueAsVariant,
             string targetNamespace,
             Namespace[] namespaces,
-            Func<string> onUnknownElement = null,
-            bool dataTypeQuirk = false)
+            Func<string> onUnknownElement = null)
         {
             // Note that we return a typed value since we initialize a object/variant
             switch (dataType.BasicDataType)
@@ -847,21 +844,6 @@ namespace Opc.Ua.Schema.Model
                     if (decodedValue is not bool boolValue)
                     {
                         boolValue = false;
-                    }
-
-                    // If decoded value was passed, but no type info, set to concrete
-                    // type so that we correctly handle the default value below.
-                    // Otherwise fall to the back compat path that inverts the value.
-                    else if (decodedValueType.IsUnknown)
-                    {
-                        decodedValueType = TypeInfo.Scalars.Boolean;
-                    }
-                    if (dataTypeQuirk &&
-                        (defaultValue == null || decodedValueType != TypeInfo.Scalars.Boolean))
-                    {
-                        // this is technically a bug but the potential for side effects is
-                        // so large that it is better to leave as is.
-                        return MakeReturnType(boolValue ? "false" : "true");
                     }
 
                     return MakeReturnType(boolValue ? "true" : "false");


### PR DESCRIPTION
## Proposed changes

Default generated data type properties to false instead of true.

## Related Issues

- Fixes #3469 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
