### PR TITLE
fix some CTT Tests, raise SemanticChangeEvent, fix netstandard 2.1 CI

### DIFF
--- a/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
+++ b/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
@@ -4319,7 +4319,7 @@ namespace Quickstarts.ReferenceServer
                 return StatusCodes.BadIndexRangeInvalid;
             }
 
-            int number = value.GetInt32();
+            int number = (int)value.GetUInt32();
             if (number >= variable.EnumValues.Value.Count || number < 0)
             {
                 return StatusCodes.BadOutOfRange;

--- a/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
+++ b/Applications/Quickstarts.Servers/ReferenceServer/ReferenceNodeManager.cs
@@ -4286,7 +4286,7 @@ namespace Quickstarts.ReferenceServer
                 return StatusCodes.BadIndexRangeInvalid;
             }
 
-            double number = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+            double number = value.GetDouble();
 
             if (number >= variable.EnumStrings.Value.Count || number < 0)
             {
@@ -4319,7 +4319,7 @@ namespace Quickstarts.ReferenceServer
                 return StatusCodes.BadIndexRangeInvalid;
             }
 
-            int number = Convert.ToInt32(value, CultureInfo.InvariantCulture);
+            int number = value.GetInt32();
             if (number >= variable.EnumValues.Value.Count || number < 0)
             {
                 return StatusCodes.BadOutOfRange;
@@ -4388,7 +4388,7 @@ namespace Quickstarts.ReferenceServer
                     return StatusCodes.BadIndexRangeInvalid;
                 }
 
-                double number = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+                double number = value.GetDouble();
 
                 if (variable.InstrumentRange != null &&
                     (number < variable.InstrumentRange.Value.Low ||

--- a/Applications/Quickstarts.Servers/TestData/TestDataObjectState.cs
+++ b/Applications/Quickstarts.Servers/TestData/TestDataObjectState.cs
@@ -174,7 +174,7 @@ namespace TestData
                     return ServiceResult.Good;
                 }
 
-                double number = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+                double number = value.GetDouble();
 
                 if (number > range.High || number < range.Low)
                 {

--- a/Libraries/Opc.Ua.Server/Diagnostics/AuditEvents.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/AuditEvents.cs
@@ -721,6 +721,8 @@ namespace Opc.Ua.Server
                         false);
 
                     server.ReportAuditEvent(systemContext, auditCertificateEventState);
+
+                    auditCertificateEventState.Dispose();
                 }
             }
             catch (Exception ex)

--- a/Libraries/Opc.Ua.Server/Diagnostics/ParsedNodeId.cs
+++ b/Libraries/Opc.Ua.Server/Diagnostics/ParsedNodeId.cs
@@ -41,6 +41,7 @@ namespace Opc.Ua.Server
     /// for the Root Node. The ComponentPath is constructed from the SymbolicNames
     /// of one or more children of the Root Node.
     /// </remarks>
+    [Obsolete("Will be removed in a future version")]
     public class ParsedNodeId
     {
         /// <summary>

--- a/Libraries/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
@@ -2295,9 +2295,46 @@ namespace Opc.Ua.Server
                         }
 
                         monitoredItem.QueueValue(value, ServiceResult.Good, true);
+
+                        RaiseSemanticChangeEvent(systemContext, node, property);
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Raises a semantic change event to notify clients that the structure or meaning of a node has changed.
+        /// </summary>
+        protected void RaiseSemanticChangeEvent(ISystemContext systemContext, NodeState node, PropertyState property)
+        {
+            using var e = new SemanticChangeEventState(null);
+
+            var message = new TranslationInfo(
+                "SemanticChangeEvent",
+                "en-US",
+                "SemanticChangeEvent.");
+
+            e.Initialize(systemContext, null, EventSeverity.Min, new LocalizedText(message));
+
+            e.SetChildValue(
+                systemContext,
+                BrowseNames.SourceNode,
+                ObjectIds.Server,
+                false);
+            e.SetChildValue(systemContext, BrowseNames.SourceName, "Server", false);
+
+            e.CreateOrReplaceChanges(systemContext, null);
+
+            e.Changes.Value = new[]
+                            {
+                                new SemanticChangeStructureDataType
+                                {
+                                    Affected = node.NodeId,
+                                    AffectedType = property.TypeDefinitionId
+                                }
+                            }.ToArrayOf();
+
+            Server.ReportEvent(e);
         }
 
         /// <summary>

--- a/Libraries/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/AsyncCustomNodeManager.cs
@@ -4344,6 +4344,7 @@ namespace Opc.Ua.Server
             {
                 result.FilterToUse = deadbandFilter;
                 result.StatusCode = StatusCodes.Good;
+                return result;
             }
 
             // deadband filters can only be used for numeric values.

--- a/Libraries/Opc.Ua.Server/NodeManager/CustomNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/CustomNodeManager.cs
@@ -2197,9 +2197,46 @@ namespace Opc.Ua.Server
                             value);
 
                         monitoredItem.QueueValue(value, ServiceResult.Good, true);
+
+                        RaiseSemanticChangeEvent(systemContext, node, property);
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Raises a semantic change event to notify clients that the structure or meaning of a node has changed.
+        /// </summary>
+        protected void RaiseSemanticChangeEvent(ISystemContext systemContext, NodeState node, PropertyState property)
+        {
+            using var e = new SemanticChangeEventState(null);
+
+            var message = new TranslationInfo(
+                "SemanticChangeEvent",
+                "en-US",
+                "SemanticChangeEvent.");
+
+            e.Initialize(systemContext, null, EventSeverity.Min, new LocalizedText(message));
+
+            e.SetChildValue(
+                systemContext,
+                BrowseNames.SourceNode,
+                ObjectIds.Server,
+                false);
+            e.SetChildValue(systemContext, BrowseNames.SourceName, "Server", false);
+
+            e.CreateOrReplaceChanges(systemContext, null);
+
+            e.Changes.Value = new[]
+                            {
+                                new SemanticChangeStructureDataType
+                                {
+                                    Affected = node.NodeId,
+                                    AffectedType = property.TypeDefinitionId
+                                }
+                            }.ToArrayOf();
+
+            Server.ReportEvent(e);
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
@@ -793,6 +793,14 @@ namespace Opc.Ua.Server.Tests
                 Assert.That(notification.Value.StatusCode.SemanticsChanged, Is.True);
                 Assert.That(diagnostics, Has.Count.EqualTo(2));
             }
+
+            Assert.That(hadMore, Is.False);
+
+            // Verify a semantic change event was correctly reported and queued
+            m_mockServer.Verify(
+                s => s.ReportEvent(It.Is<IFilterTarget>(e => e is SemanticChangeEventState)),
+                Times.Once);
+                        
             Assert.That(monitoredItem.IsReadyToPublish, Is.False);
         }
 

--- a/Tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
+++ b/Tests/Opc.Ua.Server.Tests/AsyncCustomNodeManagerTests.cs
@@ -3190,7 +3190,7 @@ namespace Opc.Ua.Server.Tests
         }
 
         [Test]
-        public async Task ValidateMonitoringFilterAsyncDataChangeFilterDeadbandNoneOnNumericVariableReturnsBadFilterNotAllowedAsync()
+        public async Task ValidateMonitoringFilterAsyncDataChangeFilterDeadbandNoneOnNumericVariableReturnsSuccessAsync()
         {
             using TestableAsyncCustomNodeManager manager = CreateManager();
             SetupNumericTypeTree();
@@ -3207,7 +3207,7 @@ namespace Opc.Ua.Server.Tests
                 10,
                 filter).ConfigureAwait(false);
 
-            Assert.That((uint)result.StatusCode, Is.EqualTo(StatusCodes.BadFilterNotAllowed));
+            Assert.That((uint)result.StatusCode, Is.EqualTo(StatusCodes.Good));
         }
 
         [Test]

--- a/Tests/Opc.Ua.Server.Tests/ReferenceServerTest.cs
+++ b/Tests/Opc.Ua.Server.Tests/ReferenceServerTest.cs
@@ -1274,6 +1274,189 @@ namespace Opc.Ua.Server.Tests
                 logger);
         }
 
+        [Test]
+        public async Task SemanticChangeNotificationTestAsync()
+        {
+            var services = new ServerTestServices(m_server, m_secureChannelContext);
+            RequestHeader requestHeader = m_requestHeader;
+            requestHeader.Timestamp = DateTime.UtcNow;
+
+            // Step 1: Create a subscription
+            CreateSubscriptionResponse createSubscriptionResponse = await services.CreateSubscriptionAsync(
+                requestHeader,
+                100,
+                100,
+                10,
+                0,
+                true,
+                0).ConfigureAwait(false);
+
+            uint subscriptionId = createSubscriptionResponse.SubscriptionId;
+
+            // We monitor the server EventNotifier for SemanticChangeEventType
+            var serverObject = new ReadValueId { NodeId = ObjectIds.Server, AttributeId = Attributes.EventNotifier };
+            var eventFilter = new EventFilter();
+            eventFilter.AddSelectClause(
+                ObjectTypeIds.SemanticChangeEventType,
+                QualifiedName.From(BrowseNames.EventId));
+            eventFilter.AddSelectClause(
+                ObjectTypeIds.SemanticChangeEventType,
+                QualifiedName.From(BrowseNames.Changes));
+
+            // Monitor a variable from ReferenceNodeManager (AnalogItem with EngineeringUnits)
+            var nodeId = new NodeId("DataAccess_AnalogType_Double",
+                (ushort)m_server.CurrentInstance.NamespaceUris.GetIndex(Quickstarts.ReferenceServer.Namespaces.ReferenceServer));
+
+            ArrayOf<MonitoredItemCreateRequest> monitoredItems =
+            [
+                new MonitoredItemCreateRequest
+                {
+                    ItemToMonitor = serverObject,
+                    MonitoringMode = MonitoringMode.Reporting,
+                    RequestedParameters = new MonitoringParameters
+                    {
+                        ClientHandle = 1,
+                        SamplingInterval = 0,
+                        QueueSize = 100,
+                        DiscardOldest = true,
+                        Filter = new ExtensionObject(eventFilter)
+                    }
+                },
+                new MonitoredItemCreateRequest
+                {
+                    ItemToMonitor = new ReadValueId { NodeId = nodeId, AttributeId = Attributes.Value },
+                    MonitoringMode = MonitoringMode.Reporting,
+                    RequestedParameters = new MonitoringParameters
+                    {
+                        ClientHandle = 2,
+                        SamplingInterval = 0,
+                        QueueSize = 10,
+                        DiscardOldest = true
+                    }
+                }
+            ];
+
+            CreateMonitoredItemsResponse createItemsResponse = await services.CreateMonitoredItemsAsync(
+                requestHeader,
+                subscriptionId,
+                TimestampsToReturn.Both,
+                monitoredItems).ConfigureAwait(false);
+
+            ServerFixtureUtils.ValidateResponse(createItemsResponse.ResponseHeader, createItemsResponse.Results, monitoredItems);
+            Assert.AreEqual(2, createItemsResponse.Results.Count);
+            Assert.IsTrue(StatusCode.IsGood(createItemsResponse.Results[0].StatusCode));
+            Assert.IsTrue(StatusCode.IsGood(createItemsResponse.Results[1].StatusCode));
+
+            // Initial publish to clear any initial data change notifications
+            var acknowledgements = new ArrayOf<SubscriptionAcknowledgement>();
+            PublishResponse publishResponse = await services.PublishAsync(requestHeader, acknowledgements).ConfigureAwait(false);
+
+            if (publishResponse.NotificationMessage.NotificationData.Count > 0)
+            {
+                acknowledgements =
+                [
+                    new SubscriptionAcknowledgement
+                   {
+                       SubscriptionId = subscriptionId,
+                       SequenceNumber = publishResponse.NotificationMessage.SequenceNumber
+                   }
+                ];
+            }
+
+            // Step 2: Write a new value to a semantic property (EngineeringUnits)
+            var euNodeId = new NodeId("DataAccess_AnalogType_DataAccess_AnalogType_Double_EngineeringUnits",
+                (ushort)m_server.CurrentInstance.NamespaceUris.GetIndex(Quickstarts.ReferenceServer.Namespaces.ReferenceServer));
+            var engUnits = new EUInformation("V", "volt", "http://www.opcfoundation.org/UA/units/un/cefact")
+            {
+                UnitId = 4274026 // "V"
+            };
+
+            var writeValues = new WriteValue[]
+            {
+                new WriteValue
+                {
+                    NodeId = euNodeId,
+                    AttributeId = Attributes.Value,
+                    Value = new DataValue(new ExtensionObject(engUnits))
+                }
+            }.ToArrayOf();
+
+            requestHeader.Timestamp = DateTime.UtcNow;
+            WriteResponse writeResponse = await m_server.WriteAsync(
+                m_secureChannelContext,
+                requestHeader,
+                writeValues, RequestLifetime.None).ConfigureAwait(false);
+
+            ServerFixtureUtils.ValidateResponse(writeResponse.ResponseHeader, writeResponse.Results, writeValues);
+            Assert.IsTrue(StatusCode.IsGood(writeResponse.Results[0]));
+
+            // Wait for subscription to deliver the event and data change notification
+            await Task.Delay(200).ConfigureAwait(false);
+
+            // Step 3: Issue publish to receive DataChangeNotification and SemanticChangeEvent
+            publishResponse = await services.PublishAsync(
+                requestHeader,
+                acknowledgements).ConfigureAwait(false);
+
+            Assert.IsNotNull(publishResponse.NotificationMessage);
+            Assert.IsNotNull(publishResponse.NotificationMessage.NotificationData);
+            Assert.IsTrue(publishResponse.NotificationMessage.NotificationData.Count > 0);
+
+            bool dataChangeReceived = false;
+            bool semanticsChangedBitSet = false;
+            bool eventReceived = false;
+
+            foreach (ExtensionObject data in publishResponse.NotificationMessage.NotificationData)
+            {
+                if (data.TryGetEncodeable(out DataChangeNotification dcn))
+                {
+                    foreach (MonitoredItemNotification item in dcn.MonitoredItems)
+                    {
+                        if (item.ClientHandle == 2)
+                        {
+                            dataChangeReceived = true;
+                            if (item.Value.StatusCode.SemanticsChanged)
+                            {
+                                semanticsChangedBitSet = true;
+                            }
+                        }
+                    }
+                }
+                else if (data.TryGetEncodeable(out EventNotificationList enl))
+                {
+                    foreach (EventFieldList e in enl.Events)
+                    {
+                        if (e.ClientHandle == 1 && e.EventFields.Count >= 2)
+                        {
+                            var success = e.EventFields[1]
+                                .TryGetStructure<SemanticChangeStructureDataType>(out ArrayOf<SemanticChangeStructureDataType> semanticChangeEvent);
+
+                            if (success && !semanticChangeEvent.IsNull && semanticChangeEvent.Count > 0)
+                            {
+                                foreach (SemanticChangeStructureDataType change in semanticChangeEvent)
+                                {
+                                    if (change.Affected == nodeId)
+                                    {
+                                        eventReceived = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Assert.IsTrue(dataChangeReceived, "Did not receive DataChangeNotification.");
+            Assert.IsTrue(semanticsChangedBitSet, "SemanticsChanged bit is not set.");
+            Assert.IsTrue(eventReceived, "Did not receive SemanticChangeEvent.");
+
+            // Delete subscription
+            await services.DeleteSubscriptionsAsync(
+                requestHeader,
+                [subscriptionId]).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Test that Server object EventNotifier has HistoryRead bit set when history capabilities are enabled.
         /// </summary>

--- a/targets.props
+++ b/targets.props
@@ -49,9 +49,9 @@
     <When Condition="'$(CustomTestTarget)' == 'netstandard2.1'">
       <PropertyGroup>
         <NetStandardTests>true</NetStandardTests>
-        <AppTargetFrameworks>net8.0</AppTargetFrameworks>
-        <AppTargetFramework>net8.0</AppTargetFramework>
-        <TestsTargetFrameworks>net8.0</TestsTargetFrameworks>
+        <AppTargetFrameworks>net10.0</AppTargetFrameworks>
+        <AppTargetFramework>net10.0</AppTargetFramework>
+        <TestsTargetFrameworks>net10.0</TestsTargetFrameworks>
         <LibTargetFrameworks>netstandard2.1</LibTargetFrameworks>
         <LibCoreTargetFrameworks>netstandard2.1</LibCoreTargetFrameworks>
         <LibxTargetFrameworks>netstandard2.1</LibxTargetFrameworks>


### PR DESCRIPTION
## Proposed changes

fix some CTT Tests, fix netstandard 2.1 CI by using net 10 targets instead of net 8

raise semantic change event
https://reference.opcfoundation.org/Core/Part5/v105/docs/6.4.33

## Fixes

#2376 


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
