### PR TITLE
Fix DataValue(int) overload resolution bug

### DIFF
--- a/Docs/MigrationGuide.md
+++ b/Docs/MigrationGuide.md
@@ -318,6 +318,7 @@ No changes are required, however there can be subtle bugs exposed, e.g.:
 - `new Variant(object)` -> use `Variant.From(T)`
 - `Variant.Value` -> use `Variant.TryGet`, cast, or `AsBoxedObject` if absolutely necessary.
 - `DataValue.GetValue`, `DataValue.GetValueOrDefault`, ,`DataValue.Value` -> use `DataValue.WrappedValue` and the new API on Variant (e.g. `Get[Type]`,  `TryGet`)
+- `new DataValue(StatusCode)` and `new DataValue(StatusCode, DateTimeUtc)` -> use `DataValue.FromStatusCode(StatusCode)` and `DataValue.FromStatusCode(StatusCode, DateTimeUtc)`. The constructors suffered from a C# overload resolution bug where `new DataValue(42)` silently resolved to `DataValue(StatusCode)` instead of `DataValue(Variant)`, losing the value.
 
 #### APIs permanently removed
 
@@ -338,6 +339,7 @@ No changes are required, however there can be subtle bugs exposed, e.g.:
 - new `Variant(byte[])` -> use `Variant.From(ByteString)` or `new Variant(ByteString)` or `Variant.From(ArrayOf<byte>)` or `new Variant(ArrayOf<byte>)`
 - Session `Call/CallAsync(param object[])` -> use `Call/CallAsync(param Variant[])`
 - `byte[]` as ByteString -> use `ByteString`
+- `new DataValue(DataValue)` copy constructor -> use `DataValue.Copy()` instance method or `Clone()`
 
 ### Encoders and Decoders
 

--- a/Libraries/Opc.Ua.PubSub/PublishedData/DataCollector.cs
+++ b/Libraries/Opc.Ua.PubSub/PublishedData/DataCollector.cs
@@ -183,7 +183,7 @@ namespace Opc.Ua.PubSub.PublishedData
                                             dataValue = new DataValue(extensionField.Value);
                                         }
                                     }
-                                    dataValue ??= new DataValue(StatusCodes.Bad, DateTime.UtcNow);
+                                    dataValue ??= DataValue.FromStatusCode(StatusCodes.Bad, DateTime.UtcNow);
                                 }
                                 else
                                 {
@@ -304,7 +304,7 @@ namespace Opc.Ua.PubSub.PublishedData
                             catch (Exception ex)
                             {
                                 dataSet.Fields[i].Value
-                                    = new DataValue(StatusCodes.Bad, DateTime.UtcNow);
+                                    = DataValue.FromStatusCode(StatusCodes.Bad, DateTime.UtcNow);
                                 m_logger.LogInformation(ex,
                                     "Error DataCollector.CollectData for dataset {Name} field {Index}",
                                     dataSetName,

--- a/Libraries/Opc.Ua.Server/Aggregates/AggregateCalculator.cs
+++ b/Libraries/Opc.Ua.Server/Aggregates/AggregateCalculator.cs
@@ -1013,7 +1013,7 @@ namespace Opc.Ua.Server
                 // check for an exact match.
                 if (CompareTimestamps(timestamp, ii) == 0)
                 {
-                    return new DataValue(ii.Value);
+                    return ii.Value.Copy();
                 }
 
                 // looking for an end bound.

--- a/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MasterNodeManager.cs
@@ -1897,7 +1897,7 @@ namespace Opc.Ua.Server
                 // set an error code for nodes that were not handled by any node manager.
                 if (!nodesToRead[ii].Processed)
                 {
-                    value = values[ii] = new DataValue(
+                    value = values[ii] = DataValue.FromStatusCode(
                         StatusCodes.BadNodeIdUnknown,
                         DateTime.UtcNow);
                     errors[ii] = new ServiceResult(values[ii].StatusCode);
@@ -1906,7 +1906,7 @@ namespace Opc.Ua.Server
                 // update the diagnostic info and ensure the status code in the data value is the same as the error code.
                 if (errors[ii] != null && errors[ii].Code != StatusCodes.Good)
                 {
-                    value ??= values[ii] = new DataValue(errors[ii].Code, DateTime.UtcNow);
+                    value ??= values[ii] = DataValue.FromStatusCode(errors[ii].Code, DateTime.UtcNow);
 
                     value.StatusCode = errors[ii].Code;
 

--- a/Libraries/Opc.Ua.Server/NodeManager/MonitoredItem/SamplingGroup.cs
+++ b/Libraries/Opc.Ua.Server/NodeManager/MonitoredItem/SamplingGroup.cs
@@ -499,7 +499,7 @@ namespace Opc.Ua.Server
                     {
                         if (values[ii] == null)
                         {
-                            values[ii] = new DataValue(
+                            values[ii] = DataValue.FromStatusCode(
                                 StatusCodes.BadInternalError,
                                 DateTime.UtcNow);
                         }

--- a/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/MonitoredItem.cs
+++ b/Libraries/Opc.Ua.Server/Subscription/MonitoredItem/MonitoredItem.cs
@@ -865,7 +865,7 @@ namespace Opc.Ua.Server
                             value.WrappedValue);
                     }
 
-                    value = new DataValue(value);
+                    value = value.Copy();
 
                     // ensure the data value matches the error status code.
                     if (error != null && error.StatusCode.Code != 0)

--- a/Stack/Opc.Ua.Types/BuiltIn/DataValue.cs
+++ b/Stack/Opc.Ua.Types/BuiltIn/DataValue.cs
@@ -28,6 +28,7 @@
  * ======================================================================*/
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using Opc.Ua.Types;
 
@@ -87,36 +88,13 @@ namespace Opc.Ua
         }
 
         /// <summary>
-        /// Creates a deep copy of the value.
-        /// </summary>
-        /// <remarks>
-        /// Creates a new instance of the class while copying the contents
-        /// of another instance.
-        /// </remarks>
-        /// <param name="value">The DataValue to copy.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the value is null</exception>
-        public DataValue(DataValue value)
-        {
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            m_value = value.m_value.Copy();
-            StatusCode = value.StatusCode;
-            SourceTimestamp = value.SourceTimestamp;
-            SourcePicoseconds = value.SourcePicoseconds;
-            ServerTimestamp = value.ServerTimestamp;
-            ServerPicoseconds = value.ServerPicoseconds;
-        }
-
-        /// <summary>
         /// Initializes the object with a value.
         /// </summary>
         /// <remarks>
         /// Initializes the object with a value from a <see cref="Variant"/>
         /// </remarks>
         /// <param name="value">The value to set</param>
+        [OverloadResolutionPriority(1)]
         public DataValue(Variant value)
         {
             m_value = value;
@@ -129,6 +107,7 @@ namespace Opc.Ua
         /// Initializes the object with a status code.
         /// </summary>
         /// <param name="statusCode">The StatusCode to set</param>
+        [Obsolete("Use DataValue.FromStatusCode() to avoid overload ambiguity with numeric types.")]
         public DataValue(StatusCode statusCode)
         {
             m_value = Variant.Null;
@@ -142,6 +121,7 @@ namespace Opc.Ua
         /// </summary>
         /// <param name="statusCode">The status code associated with the value.</param>
         /// <param name="serverTimestamp">The timestamp associated with the status code.</param>
+        [Obsolete("Use DataValue.FromStatusCode() to avoid overload ambiguity with numeric types.")]
         public DataValue(StatusCode statusCode, DateTimeUtc serverTimestamp)
         {
             m_value = Variant.Null;
@@ -195,6 +175,34 @@ namespace Opc.Ua
             StatusCode = statusCode;
             SourceTimestamp = sourceTimestamp;
             ServerTimestamp = serverTimestamp;
+        }
+
+        /// <summary>
+        /// Creates a DataValue with only a status code (no value).
+        /// </summary>
+        /// <param name="statusCode">The status code to set.</param>
+        /// <returns>A new <see cref="DataValue"/> with the specified status code.</returns>
+        public static DataValue FromStatusCode(StatusCode statusCode)
+        {
+            return new DataValue
+            {
+                StatusCode = statusCode
+            };
+        }
+
+        /// <summary>
+        /// Creates a DataValue with a status code and a server timestamp (no value).
+        /// </summary>
+        /// <param name="statusCode">The status code to set.</param>
+        /// <param name="serverTimestamp">The server timestamp to set.</param>
+        /// <returns>A new <see cref="DataValue"/> with the specified status code and server timestamp.</returns>
+        public static DataValue FromStatusCode(StatusCode statusCode, DateTimeUtc serverTimestamp)
+        {
+            return new DataValue
+            {
+                StatusCode = statusCode,
+                ServerTimestamp = serverTimestamp
+            };
         }
 
         /// <inheritdoc/>
@@ -297,7 +305,18 @@ namespace Opc.Ua
         /// <inheritdoc/>
         public virtual object Clone()
         {
-            return MemberwiseClone();
+            return Copy();
+        }
+
+        /// <summary>
+        /// Creates a deep copy of the DataValue.
+        /// </summary>
+        /// <returns>A new <see cref="DataValue"/> that is a deep copy of this instance.</returns>
+        public DataValue Copy()
+        {
+            var copy = (DataValue)base.MemberwiseClone();
+            copy.m_value = m_value.Copy();
+            return copy;
         }
 
         /// <summary>
@@ -305,7 +324,7 @@ namespace Opc.Ua
         /// </summary>
         public new object MemberwiseClone()
         {
-            return new DataValue(this);
+            return Copy();
         }
 
         /// <summary>

--- a/Tests/Opc.Ua.Client.Tests/NodeCache/NodeCacheContextTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/NodeCache/NodeCacheContextTests.cs
@@ -434,11 +434,11 @@ namespace Opc.Ua.Client.Tests
                             var value = new DataValue();
                             if (r.AttributeId == Attributes.MinimumSamplingInterval)
                             {
-                                return new DataValue(StatusCodes.BadNotReadable);
+                                return DataValue.FromStatusCode(StatusCodes.BadNotReadable);
                             }
                             if (r.AttributeId == Attributes.Description)
                             {
-                                return new DataValue(StatusCodes.BadAttributeIdInvalid);
+                                return DataValue.FromStatusCode(StatusCodes.BadAttributeIdInvalid);
                             }
                             if (r.NodeId == nodeIds[0])
                             {
@@ -560,7 +560,7 @@ namespace Opc.Ua.Client.Tests
                     new ValueTask<IServiceResponse>(new ReadResponse
                     {
                         Results = request.NodesToRead
-                           .ConvertAll(r => new DataValue(StatusCodes.BadAlreadyExists)),
+                           .ConvertAll(r => DataValue.FromStatusCode(StatusCodes.BadAlreadyExists)),
                         DiagnosticInfos = request.NodesToRead.ConvertAll(_ => new DiagnosticInfo())
                     }))
                 .Verifiable(Times.Once);
@@ -624,7 +624,7 @@ namespace Opc.Ua.Client.Tests
                             nodes[0].Read(null, r.AttributeId, value);
                             return value;
                         }
-                        return new DataValue(StatusCodes.BadUnexpectedError);
+                        return DataValue.FromStatusCode(StatusCodes.BadUnexpectedError);
                     });
                     return new ValueTask<IServiceResponse>(new ReadResponse
                     {

--- a/Tests/Opc.Ua.Client.Tests/Session/SessionTests.cs
+++ b/Tests/Opc.Ua.Client.Tests/Session/SessionTests.cs
@@ -202,7 +202,7 @@ namespace Opc.Ua.Client.Tests
             using var sut = SessionMock.Create();
             CancellationToken ct = CancellationToken.None;
 
-            ArrayOf<DataValue> dataValues = [new DataValue(StatusCodes.BadUnexpectedError)];
+            ArrayOf<DataValue> dataValues = [DataValue.FromStatusCode(StatusCodes.BadUnexpectedError)];
             ArrayOf<DiagnosticInfo> diagnosticInfos = [];
 
             sut.Channel
@@ -594,7 +594,7 @@ namespace Opc.Ua.Client.Tests
             CancellationToken ct = CancellationToken.None;
 
             var namespaceArray = new DataValue(new Variant([Ua.Namespaces.OpcUa, "http://namespace2"]));
-            var serverArray = new DataValue(StatusCodes.BadUnexpectedError);
+            var serverArray = DataValue.FromStatusCode(StatusCodes.BadUnexpectedError);
 
             sut.Channel
                 .Setup(c => c.SendRequestAsync(
@@ -653,8 +653,8 @@ namespace Opc.Ua.Client.Tests
             using var sut = SessionMock.Create();
             CancellationToken ct = CancellationToken.None;
 
-            var namespaceArray = new DataValue(StatusCodes.BadUnexpectedError);
-            var serverArray = new DataValue(StatusCodes.BadUnexpectedError);
+            var namespaceArray = DataValue.FromStatusCode(StatusCodes.BadUnexpectedError);
+            var serverArray = DataValue.FromStatusCode(StatusCodes.BadUnexpectedError);
 
             sut.Channel
                 .Setup(c => c.SendRequestAsync(

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/JsonEncoderTests.cs
@@ -958,13 +958,13 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             },
             {
                 BuiltInType.DataValue,
-                new DataValue(StatusCodes.Good),
+                DataValue.FromStatusCode(StatusCodes.Good),
                 "{}",
                 null
             },
             {
                 BuiltInType.DataValue,
-                new DataValue(StatusCodes.BadNotWritable),
+                DataValue.FromStatusCode(StatusCodes.BadNotWritable),
                 $$$"""{"StatusCode":{"Code":{{{StatusCodes.BadNotWritable.Code}}}}}""",
                 $$$"""{"StatusCode":{"Code":{{{StatusCodes.BadNotWritable.Code}}}, "Symbol":"{{{nameof(StatusCodes.BadNotWritable)}}}"}}"""
             },

--- a/Tests/Opc.Ua.PubSub.Tests/Encoding/PubSubJsonEncoderAdditionalTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/Encoding/PubSubJsonEncoderAdditionalTests.cs
@@ -861,7 +861,7 @@ namespace Opc.Ua.PubSub.Tests.Encoding
                     BuiltInType = (byte)BuiltInType.Double,
                     ValueRank = ValueRanks.Scalar
                 },
-                Value = new DataValue(StatusCodes.BadNodeIdUnknown)
+                Value = DataValue.FromStatusCode(StatusCodes.BadNodeIdUnknown)
             };
 
             var message = new PubSubEncoding.JsonDataSetMessage(

--- a/Tests/Opc.Ua.PubSub.Tests/PublishedData/DataCollectorAdditionalTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/PublishedData/DataCollectorAdditionalTests.cs
@@ -295,7 +295,7 @@ namespace Opc.Ua.PubSub.Tests.PublishedData
         {
             var dataStore = new UaPubSubDataStore();
             var nodeId = new NodeId(100, 2);
-            dataStore.WritePublishedDataItem(nodeId, Attributes.Value, new DataValue(StatusCodes.Bad));
+            dataStore.WritePublishedDataItem(nodeId, Attributes.Value, DataValue.FromStatusCode(StatusCodes.Bad));
             DataCollector collector = CreateCollector(dataStore);
 
             var pubVar = new PublishedVariableDataType

--- a/Tests/Opc.Ua.PubSub.Tests/PublishedData/DataCollectorSetupTests.cs
+++ b/Tests/Opc.Ua.PubSub.Tests/PublishedData/DataCollectorSetupTests.cs
@@ -300,7 +300,7 @@ namespace Opc.Ua.PubSub.Tests.PublishedData
             var dataStore = new UaPubSubDataStore();
             dataStore.WritePublishedDataItem(
                 new NodeId("BadField", NamespaceIndex), Attributes.Value,
-                new DataValue(StatusCodes.Bad));
+                DataValue.FromStatusCode(StatusCodes.Bad));
 
             DataCollector collector = CreateCollector(dataStore);
             PublishedDataSetDataType pds = CreateSimpleDataSet("DS1", ("BadField", DataTypeIds.Int32));

--- a/Tests/Opc.Ua.Types.Tests/BuiltIn/DataValueTests.cs
+++ b/Tests/Opc.Ua.Types.Tests/BuiltIn/DataValueTests.cs
@@ -55,7 +55,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         }
 
         [Test]
-        public void CopyConstructorCopiesAllFields()
+        public void CopyCopiesAllFields()
         {
             var sourceTime = new DateTimeUtc(2024, 6, 15, 10, 30, 0);
             var serverTime = new DateTimeUtc(2024, 6, 15, 10, 30, 1);
@@ -65,7 +65,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
                 ServerPicoseconds = 200
             };
 
-            var copy = new DataValue(original);
+            var copy = original.Copy();
 
             Assert.That(copy.WrappedValue, Is.EqualTo(original.WrappedValue));
             Assert.That(copy.StatusCode, Is.EqualTo(original.StatusCode));
@@ -76,19 +76,10 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         }
 
         [Test]
-        public void CopyConstructorThrowsOnNull()
-        {
-#pragma warning disable IDE0004 // Remove Unnecessary Cast
-            Assert.That(() => new DataValue((DataValue)null),
-                Throws.TypeOf<ArgumentNullException>());
-#pragma warning restore IDE0004 // Remove Unnecessary Cast
-        }
-
-        [Test]
         public void ConstructorWithStatusCodeAndServerTimestamp()
         {
             var serverTime = new DateTimeUtc(2024, 1, 1, 0, 0, 0);
-            var dv = new DataValue(StatusCodes.Bad, serverTime);
+            var dv = DataValue.FromStatusCode(StatusCodes.Bad, serverTime);
 
             Assert.That(dv.StatusCode, Is.EqualTo(StatusCodes.Bad));
             Assert.That(dv.ServerTimestamp, Is.EqualTo(serverTime));
@@ -122,10 +113,43 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         [Test]
         public void ConstructorWithStatusCodeOnly()
         {
-            var dv = new DataValue(StatusCodes.BadUnexpectedError);
+            var dv = DataValue.FromStatusCode(StatusCodes.BadUnexpectedError);
 
             Assert.That(dv.StatusCode, Is.EqualTo(StatusCodes.BadUnexpectedError));
             Assert.That(dv.WrappedValue.IsNull, Is.True);
+        }
+
+        [Test]
+        public void ConstructorWithIntLiteralWrapsInVariant()
+        {
+            var dv = new DataValue(42);
+
+            Assert.That(dv.WrappedValue.IsNull, Is.False);
+            Assert.That(dv.WrappedValue, Is.EqualTo(new Variant(42)));
+            Assert.That(dv.StatusCode, Is.EqualTo(StatusCodes.Good));
+        }
+
+        [Test]
+        public void FromStatusCodeSetsStatusCodeOnly()
+        {
+            var dv = DataValue.FromStatusCode(StatusCodes.BadNodeIdUnknown);
+
+            Assert.That(dv.StatusCode, Is.EqualTo(StatusCodes.BadNodeIdUnknown));
+            Assert.That(dv.WrappedValue.IsNull, Is.True);
+            Assert.That(dv.SourceTimestamp, Is.EqualTo(DateTimeUtc.MinValue));
+            Assert.That(dv.ServerTimestamp, Is.EqualTo(DateTimeUtc.MinValue));
+        }
+
+        [Test]
+        public void FromStatusCodeWithTimestampSetsBothFields()
+        {
+            var serverTime = new DateTimeUtc(2024, 7, 1, 12, 0, 0);
+            var dv = DataValue.FromStatusCode(StatusCodes.Bad, serverTime);
+
+            Assert.That(dv.StatusCode, Is.EqualTo(StatusCodes.Bad));
+            Assert.That(dv.ServerTimestamp, Is.EqualTo(serverTime));
+            Assert.That(dv.WrappedValue.IsNull, Is.True);
+            Assert.That(dv.SourceTimestamp, Is.EqualTo(DateTimeUtc.MinValue));
         }
 
         [Test]
@@ -419,7 +443,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         [Test]
         public void IsGoodWithGoodDataValue()
         {
-            var dv = new DataValue(StatusCodes.Good);
+            var dv = DataValue.FromStatusCode(StatusCodes.Good);
 
             Assert.That(DataValue.IsGood(dv), Is.True);
         }
@@ -427,7 +451,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         [Test]
         public void IsGoodWithBadDataValue()
         {
-            var dv = new DataValue(StatusCodes.Bad);
+            var dv = DataValue.FromStatusCode(StatusCodes.Bad);
 
             Assert.That(DataValue.IsGood(dv), Is.False);
         }
@@ -441,7 +465,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         [Test]
         public void IsNotGoodWithBadDataValue()
         {
-            var dv = new DataValue(StatusCodes.Bad);
+            var dv = DataValue.FromStatusCode(StatusCodes.Bad);
 
             Assert.That(DataValue.IsNotGood(dv), Is.True);
         }
@@ -449,7 +473,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         [Test]
         public void IsNotGoodWithGoodDataValue()
         {
-            var dv = new DataValue(StatusCodes.Good);
+            var dv = DataValue.FromStatusCode(StatusCodes.Good);
 
             Assert.That(DataValue.IsNotGood(dv), Is.False);
         }
@@ -463,7 +487,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         [Test]
         public void IsUncertainWithUncertainDataValue()
         {
-            var dv = new DataValue(StatusCodes.Uncertain);
+            var dv = DataValue.FromStatusCode(StatusCodes.Uncertain);
 
             Assert.That(DataValue.IsUncertain(dv), Is.True);
         }
@@ -471,7 +495,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         [Test]
         public void IsUncertainWithGoodDataValue()
         {
-            var dv = new DataValue(StatusCodes.Good);
+            var dv = DataValue.FromStatusCode(StatusCodes.Good);
 
             Assert.That(DataValue.IsUncertain(dv), Is.False);
         }
@@ -485,7 +509,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         [Test]
         public void IsNotUncertainWithGoodDataValue()
         {
-            var dv = new DataValue(StatusCodes.Good);
+            var dv = DataValue.FromStatusCode(StatusCodes.Good);
 
             Assert.That(DataValue.IsNotUncertain(dv), Is.True);
         }
@@ -493,7 +517,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         [Test]
         public void IsNotUncertainWithUncertainDataValue()
         {
-            var dv = new DataValue(StatusCodes.Uncertain);
+            var dv = DataValue.FromStatusCode(StatusCodes.Uncertain);
 
             Assert.That(DataValue.IsNotUncertain(dv), Is.False);
         }
@@ -507,7 +531,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         [Test]
         public void IsBadWithBadDataValue()
         {
-            var dv = new DataValue(StatusCodes.Bad);
+            var dv = DataValue.FromStatusCode(StatusCodes.Bad);
 
             Assert.That(DataValue.IsBad(dv), Is.True);
         }
@@ -515,7 +539,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         [Test]
         public void IsBadWithGoodDataValue()
         {
-            var dv = new DataValue(StatusCodes.Good);
+            var dv = DataValue.FromStatusCode(StatusCodes.Good);
 
             Assert.That(DataValue.IsBad(dv), Is.False);
         }
@@ -529,7 +553,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         [Test]
         public void IsNotBadWithGoodDataValue()
         {
-            var dv = new DataValue(StatusCodes.Good);
+            var dv = DataValue.FromStatusCode(StatusCodes.Good);
 
             Assert.That(DataValue.IsNotBad(dv), Is.True);
         }
@@ -537,7 +561,7 @@ namespace Opc.Ua.Types.Tests.BuiltIn
         [Test]
         public void IsNotBadWithBadDataValue()
         {
-            var dv = new DataValue(StatusCodes.Bad);
+            var dv = DataValue.FromStatusCode(StatusCodes.Bad);
 
             Assert.That(DataValue.IsNotBad(dv), Is.False);
         }

--- a/Tests/Opc.Ua.Types.Tests/Encoders/BinaryEncoderTests.cs
+++ b/Tests/Opc.Ua.Types.Tests/Encoders/BinaryEncoderTests.cs
@@ -4595,7 +4595,7 @@ namespace Opc.Ua.Types.Tests.Encoders
             // Arrange
             IServiceMessageContext context = CreateContextWithNegativeMaxStringLength();
             using var encoder = new BinaryEncoder(context);
-            var dataValue = new DataValue(StatusCodes.Bad);
+            var dataValue = DataValue.FromStatusCode(StatusCodes.Bad);
             // Act
             encoder.WriteDataValue("test", dataValue);
             byte[] result = encoder.CloseAndReturnBuffer();
@@ -4868,7 +4868,7 @@ namespace Opc.Ua.Types.Tests.Encoders
             using var encoder = new BinaryEncoder(context);
             FieldInfo field = type.GetField(fieldName);
             var statusCode = (StatusCode)field.GetValue(null);
-            var dataValue = new DataValue(statusCode);
+            var dataValue = DataValue.FromStatusCode(statusCode);
             // Act
             encoder.WriteDataValue("test", dataValue);
             byte[] result = encoder.CloseAndReturnBuffer();

--- a/Tests/Opc.Ua.Types.Tests/Encoders/JsonDecoderTests.cs
+++ b/Tests/Opc.Ua.Types.Tests/Encoders/JsonDecoderTests.cs
@@ -311,7 +311,7 @@ namespace Opc.Ua.Types.Tests.Encoders
         {
             using JsonDecoder reader = NewDecoder(Body(/*lang=json,strict*/ """{ "StatusCode": {}, "ServerPicoseconds": 123 }"""));
             DataValue result = reader.ReadDataValue(JsonProperties.Value);
-            Assert.That(result, Is.EqualTo(new DataValue(StatusCodes.Good) { ServerPicoseconds = 123 }));
+            Assert.That(result, Is.EqualTo(new DataValue(Variant.Null, StatusCodes.Good) { ServerPicoseconds = 123 }));
         }
 
         [Test]
@@ -319,7 +319,7 @@ namespace Opc.Ua.Types.Tests.Encoders
         {
             using JsonDecoder reader = NewDecoder(Body(/*lang=json,strict*/ """{ "StatusCode": {}, "ServerPicoseconds": 123 }"""), true);
             DataValue result = reader.ReadDataValue(JsonProperties.Value);
-            Assert.That(result, Is.EqualTo(new DataValue(StatusCodes.Good) { ServerPicoseconds = 0 }));
+            Assert.That(result, Is.EqualTo(new DataValue(Variant.Null, StatusCodes.Good) { ServerPicoseconds = 0 }));
         }
 
         [Test]
@@ -343,7 +343,7 @@ namespace Opc.Ua.Types.Tests.Encoders
         {
             using JsonDecoder reader = NewDecoder(Body(/*lang=json,strict*/ """{ "StatusCode": {}, "SourcePicoseconds": 123 }"""));
             DataValue result = reader.ReadDataValue(JsonProperties.Value);
-            Assert.That(result, Is.EqualTo(new DataValue(StatusCodes.Good) { SourcePicoseconds = 123 }));
+            Assert.That(result, Is.EqualTo(new DataValue(Variant.Null, StatusCodes.Good) { SourcePicoseconds = 123 }));
         }
 
         [Test]
@@ -351,7 +351,7 @@ namespace Opc.Ua.Types.Tests.Encoders
         {
             using JsonDecoder reader = NewDecoder(Body(/*lang=json,strict*/ """{ "StatusCode": {}, "SourcePicoseconds": 123 }"""), true);
             DataValue result = reader.ReadDataValue(JsonProperties.Value);
-            Assert.That(result, Is.EqualTo(new DataValue(StatusCodes.Good) { SourcePicoseconds = 0 }));
+            Assert.That(result, Is.EqualTo(new DataValue(Variant.Null, StatusCodes.Good) { SourcePicoseconds = 0 }));
         }
 
         [Test]


### PR DESCRIPTION
## Proposed changes

Fixes #3717

`new DataValue(42)` silently resolved to `DataValue(StatusCode)` instead of `DataValue(Variant)` due to C#'s **better conversion target** rule (§12.6.4.7). `StatusCode` wins because `implicit operator Variant(StatusCode)` exists, making it "more specific" than `Variant`.

**Result**: `m_value = Variant.Null`, `StatusCode = 42` — value silently lost, downstream writes fail with `BadTypeMismatch`.

## Fix

### DataValue.cs
- **`[OverloadResolutionPriority(1)]`** on `DataValue(Variant)` — steers numeric literals to Variant
- **`[Obsolete]`** on `DataValue(StatusCode)` and `DataValue(StatusCode, DateTimeUtc)`
- **New factory methods**: `DataValue.FromStatusCode(StatusCode)` and `DataValue.FromStatusCode(StatusCode, DateTimeUtc)`
- **Deleted** `DataValue(DataValue)` copy constructor — replaced with `DataValue.Copy()` instance method
- **Rewrote** `Clone()`/`MemberwiseClone()` to use `base.MemberwiseClone()` + `m_value.Copy()`, bypassing constructor dispatch

### Call-site migrations (14 files)
- All `new DataValue(StatusCodes.X)` → `DataValue.FromStatusCode(StatusCodes.X)`
- `new DataValue(value)` copy usage → `value.Copy()`

### Tests
- New: `ConstructorWithIntLiteralWrapsInVariant` — verifies `new DataValue(42)` produces `Variant(42)`
- New: `FromStatusCodeSetsStatusCodeOnly`, `FromStatusCodeWithTimestampSetsBothFields`
- Updated: copy constructor test → `Copy()` method test

### Documentation
- Updated `Docs/MigrationGuide.md` with entries for obsoleted and removed APIs

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [x] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.